### PR TITLE
Add host to keycloak config

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -37,6 +37,7 @@ class EnvironmentConfig(NamedTuple):
 
 
 class KeycloakConfig(NamedTuple):
+    host: str = "plaidcloud.io"
     realm: str = "PlaidCloud"
     client_name: str = "plaidcloud-login"
     keycloak_issuer: str = "https://plaidcloud.io/auth/realms/PlaidCloud"


### PR DESCRIPTION
Allows us to point dev workspaces at IO keycloak and beta at prod keycloak