### PR TITLE
Superset

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -63,3 +63,7 @@ services:
   rpc: http://plaid-rpc/json-rpc/
   superset: http://plaid-superset
   workflow: http://plaid-workflow
+superset:
+  use_event_handler: false
+  username: admin
+  password: admin

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -103,6 +103,11 @@ class OpenSearchConfig(NamedTuple):
     password: str = ""
     port: int = 9200
 
+class SupersetConfig(NamedTuple):
+    username: str = "admin"
+    password: str = ""
+    use_events_handler: bool = True
+
 
 class LokiConfig(NamedTuple):
     host: str = "loki-gateway"
@@ -237,6 +242,11 @@ class PlaidConfig:
     def service_urls(self) -> ServiceConfig:
         svc_config = self.cfg.get('services', {})
         return ServiceConfig(**svc_config)
+
+    @property
+    def superset(self) -> SupersetConfig:
+        superset_config = self.cfg.get('superset', {})
+        return SupersetConfig(**superset_config)
 
     def __str__(self):
         return repr(self)


### PR DESCRIPTION
Adds a little bit of superset configuration info to plaid-config

These lines need to be added to the plaid-config for a tenant (or control-plane, or whatever):

```
superset:
  use_events_handler: false
  username: admin
  password: admin
```

We may want to change that password - this is the default from the superset_init we're using in tenants

If these lines aren't added, use_events_handler will default to True, and it will continue to work the way it always has