### PR TITLE
Add headless support

### DIFF
--- a/.github/workflows/pr_lint.yaml
+++ b/.github/workflows/pr_lint.yaml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Ensure python 3.11
+      - name: Ensure python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Acquire list of changed python files
         id: all-python-files
         continue-on-error: true
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             **/*.py
       - name: Install dependencies
-        run: pip install pyyaml requests; pip install -q pylint==2.15.5;
+        run: pip install pyyaml requests setuptools; pip install -q pylint==${{ secrets.PYLINT_VERSION }};
       - name: Install ReviewDog
         uses: reviewdog/action-setup@v1
       - name: Check Lint Warnings

--- a/python/plaidcloud/config/redis.py
+++ b/python/plaidcloud/config/redis.py
@@ -21,6 +21,7 @@ from urllib import parse as urlparse
 # "sentinel://plaid-redis-master:6379/plaid/0"
 # "sentinel://elaborate_password@plaid-redis-master:6379/plaid/0"
 # "sentinel://elaborate_password@plaid-redis-master,different-host:6380/1?name=goof&socket_timeout=2.5"
+# "sentinel+headless://elaborate_password@headless_host:26379/1?name=goof&socket_timeout=2.5&quorum=2"
 # "redis-cluster://plaid-redis-master:6379"
 # "redis-cluster://elaborate_password:plaid-redis-master:6379"
 
@@ -34,6 +35,8 @@ class ParsedRedisURL(NamedTuple):
     service_name: str
     database: int = 0
     cluster: bool = False
+    headless: bool = False
+    quorum: int = 0
     # options: 
 
 
@@ -52,7 +55,10 @@ class RedisConfig():
             url = urlparse.urlparse(url)
 
         def is_sentinel():
-            return url.scheme == 'redis+sentinel' or url.scheme == 'sentinel'
+            return url.scheme == 'redis+sentinel' or url.scheme == 'sentinel' or url.scheme == 'sentinel+headless'
+
+        def is_headless():
+            return 'headless' in url.scheme
 
         def is_cluster():
             return url.scheme == 'redis-cluster'
@@ -90,6 +96,7 @@ class RedisConfig():
             'client_type': str,
             'socket_timeout': float,
             'socket_connect_timeout': float,
+            'quorum': int,
         }
         options = {}
 
@@ -138,4 +145,6 @@ class RedisConfig():
             master=(client_type == "master"),
             service_name=service_name,
             database=db,
+            headless=is_headless(),
+            quorum=options.get("quorum", 0),
         )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools >= 40.0.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 125
+target-version = ['py311']
+skip-string-normalization = true


### PR DESCRIPTION
Allows to specify in the url if the service is headless. This allows us to use a revised Sentinel connection in the app that will requery the list of sentinel IPs