### PR TITLE
Allow URL for cloud database to be different from Analyze

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -28,6 +28,7 @@ class DatabaseConfig(NamedTuple):
     system: str
     database_name: str = "plaid_data"
     query_params: dict = {}
+    cloud_url: str = ""
 
 
 class EnvironmentConfig(NamedTuple):


### PR DESCRIPTION
This will allow us to specify Postgres for the Cloud DB, or to leave the cloud DB in Greenplum until we want to move it. 
Complementary PR in plaid.