### PR TITLE
Add panel_builder_image to EnvironmentConfig

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -42,6 +42,7 @@ class EnvironmentConfig(NamedTuple):
     tempdir: str = "/tmp"
     verify_ssl: bool = False
     workflow_image: str = ""
+    panel_builder_image: str = ""
 
 
 class KeycloakConfig(NamedTuple):


### PR DESCRIPTION
## Summary
- Adds `panel_builder_image: str = \"\"` to `EnvironmentConfig`, mirroring `workflow_image`
- Consumed by plaid to dispatch panel-builder K8s jobs (analogous to workflow-runner)

## Test plan
- [x] Default empty string keeps existing tenants unaffected
- [x] `environment` property filters by `_fields` so tenant YAMLs with the new key populate it automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)