### PR TITLE
Add EmailConfig NamedTuple + cfg.email property

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -71,6 +71,10 @@ services:
 stripe:
   api_key: ""
   webhook_secret: ""
+email:
+  postmark_server_token: ""
+  postmark_server_id: ""
+  sender: ""
 superset:
   use_event_handler: false
   username: admin

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -185,6 +185,12 @@ class StripeConfig(NamedTuple):
     webhook_secret: str = ""
 
 
+class EmailConfig(NamedTuple):
+    postmark_server_token: str = ""
+    postmark_server_id: str = ""
+    sender: str = ""
+
+
 class VaultConfig(NamedTuple):
     enabled: bool = False
     url: str = "http://127.0.0.1:8200"
@@ -296,6 +302,11 @@ class PlaidConfig:
     def stripe(self) -> StripeConfig:
         stripe_config = self.cfg.get('stripe', {})
         return StripeConfig(**{k: v for k, v in stripe_config.items() if k in StripeConfig._fields})
+
+    @property
+    def email(self) -> EmailConfig:
+        email_config = self.cfg.get('email', {})
+        return EmailConfig(**{k: v for k, v in email_config.items() if k in EmailConfig._fields})
 
     @property
     def vault(self) -> VaultConfig:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -174,6 +174,11 @@ SAMPLE_CONFIG = {
         "api_key": "sk_test_123",
         "webhook_secret": "whsec_test_456",
     },
+    "email": {
+        "postmark_server_token": "pmk-server-token",
+        "postmark_server_id": "pmk-server-id",
+        "sender": "no-reply@example.com",
+    },
     "vault": {
         "enabled": True,
         "url": "http://vault:8200",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -33,6 +33,7 @@ SharedPostgresConfig = config_mod.SharedPostgresConfig
 OAuthConfig = config_mod.OAuthConfig
 OAuthServiceConfig = config_mod.OAuthServiceConfig
 StripeConfig = config_mod.StripeConfig
+EmailConfig = config_mod.EmailConfig
 VaultConfig = config_mod.VaultConfig
 PlaidConfig = config_mod.PlaidConfig
 
@@ -425,6 +426,26 @@ class TestStripeConfig:
         stripe = missing_config.stripe
         assert stripe.api_key == ""
         assert stripe.webhook_secret == ""
+
+
+# ---------------------------------------------------------------------------
+# EmailConfig
+# ---------------------------------------------------------------------------
+
+class TestEmailConfig:
+
+    def test_full_config(self, plaid_config):
+        email = plaid_config.email
+        assert isinstance(email, EmailConfig)
+        assert email.postmark_server_token == "pmk-server-token"
+        assert email.postmark_server_id == "pmk-server-id"
+        assert email.sender == "no-reply@example.com"
+
+    def test_defaults(self, missing_config):
+        email = missing_config.email
+        assert email.postmark_server_token == ""
+        assert email.postmark_server_id == ""
+        assert email.sender == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `EmailConfig` NamedTuple with `postmark_server_token`, `postmark_server_id`, `sender` defaults
- Exposes it via `cfg.email` on `PlaidConfig`
- Adds an `email:` section to `dev-config.yaml` and `SAMPLE_CONFIG`
- Adds full-config + defaults tests alongside the existing NamedTuple test fixtures (all 43 tests pass)

## Why
Prerequisite for the Email management area being added to `plaid`. The backend client at `plaid/core/utility/postmark_server.py` reads the per-tenant Postmark server token from `cfg.email.postmark_server_token` so it can authenticate against that tenant's virtual Postmark server.

## Depends on / paired with
- **plaidcloud-cp-rest** `feat/email-postmark`: writes `postmark_server_token` / `postmark_server_id` into each tenant's `tenantMeta` block in the values YAML, and adds `POST /tenants/republish-all` to backfill existing tenants
- **plaid-tenant-infrastructure** `feat/email-postmark`: renders the `email:` block into the tenant configmap so it reaches `/etc/plaidcloud/config.yaml`
- **plaid** `feat/email-postmark` (not yet opened): the feature that consumes `cfg.email`

## Test plan
- [x] `pytest python/tests/test_config.py` — 43 tests pass
- [ ] Verify tenants with no `email:` block still load config cleanly (all fields default to `""`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)