### PR TITLE
TenantConfig: add workflow_run_history field

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -104,6 +104,8 @@ class TenantConfig(NamedTuple):
     app_logo_url: str = "resource/plaid/images/logo-header.png"
     splash_screen_logo_url: str = "resource/plaid/images/logo-login.png"
     superset_logo_url: str = "/static/assets/images/plaidcloud.png"
+    workflow_run_history: dict = {}
+
 
 class GlobalConfig(NamedTuple):
     client_id: str = ""

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -84,6 +84,12 @@ SAMPLE_CONFIG = {
         "app_logo_url": "logo.png",
         "splash_screen_logo_url": "splash.png",
         "superset_logo_url": "superset.png",
+        "workflow_run_history": {
+            "writer_user": "wfh_writer",
+            "writer_password": "wpw",
+            "reader_user": "wfh_reader",
+            "reader_password": "rpw",
+        },
     },
     "services": {
         "auth": "http://auth:8080",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -238,12 +238,19 @@ class TestTenantConfig:
         assert t.cloud_id == 42
         assert t.apps == ["app1", "app2"]
         assert t.use_proxy_download is True
+        assert t.workflow_run_history == {
+            "writer_user": "wfh_writer",
+            "writer_password": "wpw",
+            "reader_user": "wfh_reader",
+            "reader_password": "rpw",
+        }
 
     def test_defaults(self, missing_config):
         t = missing_config.tenant
         assert t.github_token == ""
         assert t.apps == []
         assert t.cloud_id == 0
+        assert t.workflow_run_history == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `workflow_run_history: dict = {}` to `TenantConfig` so the new tenant-config block introduced by Visual Workflow Designer Stage A (PlaidCloud/plaidcloud-cp-rest#126) survives loader-side stripping.

## Why

Stage A's chart-side ESO template renders this fragment under `tenant:` in `/etc/plaidcloud/config.yaml`:

\`\`\`yaml
tenant:
  workflow_run_history:
    writer_user: wfh_writer
    writer_password: \"<from-vault>\"
    reader_user: wfh_reader
    reader_password: \"<from-vault>\"
\`\`\`

Plaid's `bootstrap_workflow_run_history` then reads `cfg.tenant.workflow_run_history` to decide whether to provision the per-tenant run-history schema (StarRocks DB + writer/reader users + step_run table + daily heatmap MV).

Because `TenantConfig` is a strict `NamedTuple`, any key not declared on the class is silently dropped during loading. Without this field, even a correctly-rendered config.yaml leaves `getattr(cfg.tenant, 'workflow_run_history', None)` returning None — bootstrap skips, the `/step-run-record` endpoint 503s, and the new heatmap columns in the workflow step table never populate.

## Pattern

Modeled on the existing `google` / `aws` / `azure` / `private_cloud` fields — pass-through `dict`, no schema expectation beyond presence. The keys inside (`writer_user`, `writer_password`, `reader_user`, `reader_password`) are the contract between cp-rest and plaid; `plaidcloud-config` just needs to not strip them.

## Test plan

- [x] New assertions in `TestTenantConfig.test_full_config` and `.test_defaults` covering both populated and empty cases
- [x] Updated `SAMPLE_CONFIG` fixture in conftest.py with the wfh block
- [x] Full local test suite: 43 passed

## Dependencies

Required for the Stage A end-to-end chain to complete on any tenant:

1. ✅ cp-rest PR #126 — generates wfh creds + writes them to Vault
2. ✅ Chart-side ESO template fragment (already merged to plaid-tenant-infrastructure)
3. **This PR** — TenantConfig schema field
4. plaid \`feat/visual-workflow-designer-stage-a\` — consumer (open PR pending)
5. workflow-runner \`feat/visual-workflow-designer-stage-a\` — POSTs records (open PR pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)