### PR TITLE
feat: per-tenant signing secrets + AI provider keys (config schema)

### DIFF
--- a/.github/claude-review-guidelines.md
+++ b/.github/claude-review-guidelines.md
@@ -1,0 +1,99 @@
+# Claude PR Reviewer — Guidelines
+
+You are a senior code reviewer for this repository. Reviews are posted automatically
+on every non-draft pull request, and on `@claude` mentions in PR threads. Behave like
+a thoughtful, time-constrained peer reviewer — not a linter, not a cheerleader.
+
+## What to focus on (priority order)
+
+1. **Correctness bugs.** Off-by-one, race conditions, null/None handling, incorrect
+   error propagation, broken control flow, wrong condition order, missing await,
+   shadowed variables that change semantics.
+2. **Security issues.** Injection (SQL/shell/template), unsafe deserialization, secrets
+   committed, auth/authz bypasses, SSRF, path traversal, unsafe redirects, weak crypto,
+   missing input validation on trust boundaries.
+3. **Data integrity & concurrency.** Missing transactions, lost updates, partial writes
+   on failure paths, non-idempotent retries, broken invariants.
+4. **API/contract breakage.** Removed or renamed public surface, changed signatures
+   without backcompat, changed default values that callers depend on, schema changes
+   without migration.
+5. **Performance in hot paths.** N+1 queries, accidental quadratic loops, unbounded
+   memory growth, blocking I/O on event loops, missing indexes implied by new queries.
+6. **Test gaps.** New behavior with no test, regression scenarios uncovered, tests that
+   assert nothing meaningful, removed tests without justification.
+7. **Maintainability red flags.** Functions that obviously do too much, leaky
+   abstractions, duplicated logic, comments that lie about the code.
+
+## What NOT to do
+
+- Don't comment on formatting, naming, or style unless it's genuinely confusing. The
+  linter and formatter handle this.
+- Don't restate what the code does. Add value or stay silent.
+- Don't suggest renames unless the existing name is actively misleading.
+- Don't praise. No "great work", no "LGTM", no emojis.
+- Don't pile on minor suggestions; cap yourself at the most important findings.
+- Don't approve a PR with an unresolved correctness or security concern.
+- Don't request changes for taste-based preferences — flag them as suggestions in
+  the summary instead.
+
+## Verdict policy
+
+- **APPROVE**: change is correct and any inline comments are clearly minor / optional.
+- **COMMENT**: substantive feedback that the author should consider, but nothing
+  blocks merging.
+- **REQUEST_CHANGES**: at least one inline comment identifies a real correctness,
+  security, or contract-breaking issue.
+
+## Inline comment quality bar
+
+Each inline comment should:
+- Point at a specific line in the diff (not "somewhere in this file").
+- State the concern in one or two sentences.
+- Where useful, suggest a concrete fix or ask a pointed question.
+- Avoid hedging like "you might consider possibly thinking about maybe…".
+
+## Tone
+
+Direct, technical, peer-to-peer. Write the way a senior engineer reviews their
+teammate's PR over coffee. Confident but not arrogant; willing to ask "why this
+approach?" when the reasoning isn't obvious.
+
+## Repo-specific context: CLAUDE.md
+
+Before reviewing, also check the repo root for a `CLAUDE.md` file and read it
+if present. Treat it as authoritative for repo-specific facts:
+
+- Architecture overview and module ownership
+- Coding conventions specific to this codebase
+- Deprecation status of modules (don't suggest improvements to code that's
+  being removed)
+- Performance/security constraints particular to this system
+- Do-not-touch areas, generated files, vendored code
+- Build/test/lint commands and how to validate locally
+
+`CLAUDE.md` is the same file Claude Code uses for repo guidance, so a repo
+that already has one for developer Claude Code sessions will work without
+changes.
+
+**Precedence rules** when this file and `CLAUDE.md` disagree:
+
+- For *repo-specific facts* (e.g. "we use snake_case here", "the `legacy/`
+  directory is frozen"), `CLAUDE.md` wins.
+- For *review style and verdict policy* (priority list above, tone, what NOT
+  to do, APPROVE vs. REQUEST_CHANGES threshold), THIS file wins.
+
+If a repo has no `CLAUDE.md`, fall back to the generic baseline below and
+infer conventions from the existing code.
+
+## Generic baseline (used when CLAUDE.md is absent)
+
+<!--
+  Adjust per organization. These are sensible defaults for a Python repo.
+-->
+
+- Primary language: Python 3.12+. Type hints required on public functions.
+- Tests live in `tests/` mirroring source layout. New behavior needs a test.
+- New runtime dependencies need a justification in the PR description.
+- Public APIs are defined under `src/<pkg>/__init__.py`; changes there are
+  contract changes and need a CHANGELOG entry.
+- Database migrations live in `migrations/`; never edit a merged migration.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,617 @@
+name: Claude PR Review
+
+# ------------------------------------------------------------------------------
+# Trigger policy (intentional):
+#   * `pull_request`         — opened / reopened / ready_for_review ONLY.
+#                              We deliberately do NOT include `synchronize`, so
+#                              new commits after the initial review do NOT cause
+#                              another automatic review. Re-engage Claude by
+#                              @-mentioning it instead.
+#   * `issue_comment`        — any new top-level PR comment containing `@claude`.
+#   * `pull_request_review_comment`
+#                            — any new inline review comment containing `@claude`.
+#
+# Pipeline:
+#   pull_request → triage → review        (every eligible PR gets a review)
+#   review can't run     → status         (posts a "did not run" comment)
+#   comment with @claude → followup       (always Sonnet)
+#
+# Review policy: every eligible PR gets a posted GitHub Review — no silent
+# skip. Trivial PRs (tiny diff / lockfile-only) still get a cheap Haiku review
+# that APPROVEs only after reading the diff and finding no real issues.
+#
+# Cost / noise guardrails:
+#   * `paths-ignore`        — docs/lockfile-only PRs never trigger the workflow.
+#   * Free pre-flight gate  — routes tiny / lockfile-only PRs to the cheap
+#                             Haiku tier (no triage API call); never skips.
+#   * Haiku triage          — one cheap Haiku call picks Haiku vs Sonnet review.
+#   * Author filter         — `[bot]` authors are skipped (dependabot, etc.).
+#   * Draft filter          — drafts are skipped.
+#   * Concurrency           — cancels in-flight jobs on the same PR.
+#   * Self-call guard       — bot comments don't re-trigger the bot.
+# ------------------------------------------------------------------------------
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    # Deliberately NOT ignored: `**/*.md` (the reviewer's own playbook is .md
+    # and must be reviewed) and `**/*.txt` (requirements.txt dependency bumps
+    # are exactly the supply-chain change that needs review). Trivial doc-only
+    # PRs are handled cheaply by the Haiku tier, not dropped.
+    paths-ignore:
+      - '**/*.rst'
+      - '**/*.adoc'
+      - '**/CHANGELOG*'
+      - '**/LICENSE*'
+      - '**.lock'
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**/pnpm-lock.yaml'
+      - '**/poetry.lock'
+      - '**/uv.lock'
+      - '**/Pipfile.lock'
+      - '**/Cargo.lock'
+      - '**/Gemfile.lock'
+      - '**/composer.lock'
+      - '**/go.sum'
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  # No id-token: write — we authenticate with anthropic_api_key + github_token
+  # directly, not OIDC federation. Least-privilege matters here because this
+  # workflow hands Bash to an LLM reading untrusted PR content.
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  # false, not true: an @claude comment or a reopen while a review is still
+  # running must NOT cancel that in-flight review (it would never post). We
+  # don't trigger on `synchronize`, so rapid-fire runs aren't a cost concern.
+  cancel-in-progress: false
+
+jobs:
+  # ============================================================================
+  # Triage — free pre-flight gate (classifies trivial vs normal) + Haiku
+  # decision. Outputs the review tier (haiku-review / sonnet-review) or
+  # `no-key` when no API key is configured. Never emits a skip.
+  # ============================================================================
+  triage:
+    # author_association gate: only OWNER/MEMBER/COLLABORATOR PRs are auto-
+    # reviewed. Fork PRs from outside contributors get no secrets anyway (so
+    # the review job is skipped via the missing-key guard); this also stops
+    # the triage API spend on untrusted PRs. Trade-off: external/OSS PRs are
+    # not auto-reviewed — re-engage with an @claude comment from a maintainer.
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      !endsWith(github.event.pull_request.user.login, '[bot]') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      verdict: ${{ steps.decide.outputs.verdict }}
+      reason:  ${{ steps.decide.outputs.reason }}
+      model:   ${{ steps.decide.outputs.model }}
+    steps:
+      # SECURITY: egress firewall — MUST be the first step. Blocks all
+      # outbound traffic except the allowlist, so a prompt-injected jailbreak
+      # cannot exfiltrate ANTHROPIC_API_KEY / the GitHub token to attacker
+      # infrastructure even though Claude has Bash. disable-sudo stops a
+      # jailbreak from tearing the firewall down. If a legitimate run is
+      # blocked, the run summary names the denied endpoint — add it below
+      # (or set egress-policy: audit briefly to learn the set).
+      - name: Harden runner (egress firewall)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.anthropic.com:443
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      # ------------------------------------------------------------------------
+      # Free pre-flight: classify the PR. Tiny diffs and lockfile-only PRs are
+      # routed to the cheap Haiku tier (skipping the triage API call), never
+      # dropped — every eligible PR still gets a posted review.
+      # ------------------------------------------------------------------------
+      - name: Pre-flight gate
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          PR:   ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          MIN_LINES: "10"
+        run: |
+          set -euo pipefail
+
+          info=$(gh pr view "$PR" --repo "$REPO" --json additions,deletions,files)
+          adds=$(jq -r '.additions' <<<"$info")
+          dels=$(jq -r '.deletions' <<<"$info")
+          total=$((adds + dels))
+          echo "Diff size: +$adds / -$dels  ($total lines)"
+
+          # `exit 0` ends THIS step successfully; it does not skip the job.
+          # Later steps gate on steps.gate.outputs.tier.
+          if [ "$total" -lt "$MIN_LINES" ]; then
+            echo "tier=trivial" >> "$GITHUB_OUTPUT"
+            echo "reason=small diff ($total lines)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          non_lock=$(jq -r '
+            [.files[] | select(.path |
+              test("(^|/)(package-lock\\.json|yarn\\.lock|pnpm-lock\\.yaml|poetry\\.lock|uv\\.lock|Pipfile\\.lock|Cargo\\.lock|Gemfile\\.lock|composer\\.lock|go\\.sum)$") | not
+            )] | length
+          ' <<<"$info")
+          if [ "$non_lock" -eq 0 ]; then
+            echo "tier=trivial" >> "$GITHUB_OUTPUT"
+            echo "reason=lockfile-only PR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "tier=normal" >> "$GITHUB_OUTPUT"
+
+      # ------------------------------------------------------------------------
+      # Haiku triage: one short API call. Decides verdict + which model the
+      # review job should use. Only runs for the `normal` tier — trivial PRs
+      # skip straight to a cheap Haiku review (no triage call needed).
+      # ------------------------------------------------------------------------
+      - name: Haiku triage
+        id: haiku
+        if: steps.gate.outputs.tier == 'normal'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          PR:   ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HAIKU_MODEL:  "claude-haiku-4-5-20251001"
+          SONNET_MODEL: "claude-sonnet-4-6"
+        run: |
+          set -euo pipefail
+
+          # No key → can't triage or review. Emit `no-key`; the Decide step
+          # also independently checks key presence so the trivial path (which
+          # skips this step) is covered too.
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY not configured; cannot run Claude review."
+            echo "verdict=no-key"                                >> "$GITHUB_OUTPUT"
+            echo "reason=ANTHROPIC_API_KEY not configured"       >> "$GITHUB_OUTPUT"
+            echo "model="                                        >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          info=$(gh pr view "$PR" --repo "$REPO" \
+            --json title,body,additions,deletions,files)
+          title=$(jq -r '.title // ""' <<<"$info")
+          body=$(jq -r '.body  // ""' <<<"$info")
+          adds=$(jq -r '.additions' <<<"$info")
+          dels=$(jq -r '.deletions' <<<"$info")
+          files=$(jq -r '[.files[].path] | join(", ")' <<<"$info")
+          # Capture then truncate in-shell. Piping to `head -c` closes the
+          # pipe early, killing `gh` with SIGPIPE (exit 141) under
+          # `set -o pipefail` on any diff larger than the cap.
+          diff=$(gh pr diff "$PR" --repo "$REPO")
+          diff=${diff:0:8000}
+
+          user_msg=$(printf 'Triage this pull request. Pick one verdict.\n\nTitle: %s\nFiles: %s\nSize: +%s / -%s\nDescription:\n%s\n\nDiff preview (first 8KB):\n%s\n\nReply with ONLY a JSON object, no prose:\n{"verdict":"haiku-review|sonnet-review","reason":"<one short sentence>"}\n\nGuidance:\n- haiku-review: small, low-risk — trivial or formatting-only changes, dependency/lockfile bumps, style cleanup, simple refactor in internal helpers, isolated bug fix in a leaf module.\n- sonnet-review: anything with control flow changes, security boundaries, schema/API changes, concurrency, new features, error handling, or non-trivial bug fixes.\n\nWhen in doubt, prefer sonnet-review.' \
+            "$title" "$files" "$adds" "$dels" "$body" "$diff")
+
+          payload=$(jq -n \
+            --arg model "$HAIKU_MODEL" \
+            --arg content "$user_msg" \
+            '{model: $model, max_tokens: 300, messages: [{role:"user", content:$content}]}')
+
+          resp=$(curl -sS https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$payload")
+
+          raw=$(jq -r '.content[0].text // ""' <<<"$resp")
+          echo "Haiku raw output: $raw"
+
+          # Robust JSON extraction (handles markdown fences and stray prose).
+          parsed=$(python3 - <<'PY' "$raw"
+          import json, re, sys
+          t = sys.argv[1].strip()
+          if t.startswith("```"):
+              t = re.sub(r'^```(?:json)?', '', t)
+              t = re.sub(r'```$', '', t).strip()
+          m = re.search(r'\{.*\}', t, re.DOTALL)
+          if m:
+              t = m.group(0)
+          try:
+              obj = json.loads(t)
+              v = obj.get("verdict", "sonnet-review")
+              r = obj.get("reason", "(no reason)")
+          except Exception:
+              v, r = "sonnet-review", "triage parse failed; defaulting to Sonnet"
+          if v not in ("haiku-review", "sonnet-review"):
+              v, r = "sonnet-review", f"unknown verdict; defaulting ({r})"
+          # `r` is model output shaped by attacker-controllable PR content.
+          # Collapse whitespace/newlines and cap length so it can't smuggle
+          # extra lines into $GITHUB_OUTPUT or break the tab-delimited parse.
+          r = " ".join(str(r).split())[:200]
+          print(f"{v}\t{r}")
+          PY
+          )
+
+          verdict=$(cut -f1 <<<"$parsed")
+          reason=$(cut -f2 <<<"$parsed")
+
+          case "$verdict" in
+            haiku-review)  model="$HAIKU_MODEL"  ;;
+            sonnet-review) model="$SONNET_MODEL" ;;
+            *)             model="$SONNET_MODEL" ;;
+          esac
+
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason"   >> "$GITHUB_OUTPUT"
+          echo "model=$model"     >> "$GITHUB_OUTPUT"
+
+      # ------------------------------------------------------------------------
+      # Consolidate gate + Haiku outputs into job-level outputs.
+      # ------------------------------------------------------------------------
+      - name: Decide final verdict
+        id: decide
+        # Pass step outputs via env, never inline `${{ }}` into the script
+        # body: `reason` is model-derived from attacker-controllable PR
+        # content, and inline interpolation would let it execute as shell.
+        # Env expansion does not re-enter the shell parser. HAVE_KEY is the
+        # boolean result of a secret-presence test — the secret itself is
+        # never exposed.
+        env:
+          GATE_TIER:         ${{ steps.gate.outputs.tier }}
+          GATE_REASON:       ${{ steps.gate.outputs.reason }}
+          HAIKU_VERDICT:     ${{ steps.haiku.outputs.verdict }}
+          HAIKU_REASON:      ${{ steps.haiku.outputs.reason }}
+          HAIKU_MODEL:       ${{ steps.haiku.outputs.model }}
+          HAVE_KEY:          ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          HAIKU_MODEL_NAME:  "claude-haiku-4-5-20251001"
+          SONNET_MODEL_NAME: "claude-sonnet-4-6"
+        run: |
+          set -euo pipefail
+          if [ "$HAVE_KEY" != "true" ]; then
+            # No key anywhere → review job is skipped; the status job posts a
+            # visible "did not run" comment so there is never a silent skip.
+            verdict=no-key
+            reason="ANTHROPIC_API_KEY not configured"
+            model=""
+          elif [ "$GATE_TIER" = "trivial" ]; then
+            # Trivial tier still gets a real (cheap) Haiku review that decides
+            # APPROVE only after reading the diff — not a blind size approve.
+            verdict=haiku-review
+            reason="trivial — $GATE_REASON"
+            model="$HAIKU_MODEL_NAME"
+          else
+            # Normal tier: trust the Haiku triage, but never silently skip —
+            # fail safe to a Sonnet review if triage produced no output.
+            verdict="${HAIKU_VERDICT:-sonnet-review}"
+            reason="${HAIKU_REASON:-haiku triage produced no output; defaulting to Sonnet}"
+            model="${HAIKU_MODEL:-$SONNET_MODEL_NAME}"
+          fi
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason"   >> "$GITHUB_OUTPUT"
+          echo "model=$model"     >> "$GITHUB_OUTPUT"
+          echo "::notice::Triage verdict: $verdict — $reason (model: ${model:-none})"
+
+  # ============================================================================
+  # Review — runs the model the triage job selected. Every eligible PR reaches
+  # here; only `no-key` (or triage not running, e.g. draft / fork) skips it,
+  # and the status job then posts a visible "did not run" comment.
+  # ============================================================================
+  review:
+    needs: triage
+    if: needs.triage.outputs.verdict == 'haiku-review' || needs.triage.outputs.verdict == 'sonnet-review'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # SECURITY: egress firewall — see rationale in the triage job. This is
+      # the primary exfil control for the Bash + secrets review context.
+      - name: Harden runner (egress firewall)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.anthropic.com:443
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review (${{ needs.triage.outputs.verdict }})
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          # SECURITY: `Bash` is required for the `gh pr view/diff/api` calls
+          # the review flow makes. The egress firewall (harden-runner, first
+          # step, block + disable-sudo) is the PRIMARY exfil control: a
+          # jailbroken Claude cannot reach attacker infra and cannot tear the
+          # firewall down. Defense-in-depth: CLAUDE_REVIEWER_TOKEN MUST be a
+          # fine-grained token scoped to THIS repo only, permissions Pull
+          # requests: read/write, Contents: read, Metadata: read — nothing
+          # else (no Contents write, no admin). Residual:
+          # exfil via an allowed host (e.g. posting a secret into a PR comment)
+          # is still possible but noisy, visible, and token-scope-limited.
+          claude_args: >-
+            --model ${{ needs.triage.outputs.model }}
+            --max-turns 30
+            --allowedTools Read,Grep,Glob,Bash
+          prompt: |
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }}.
+
+            Triage tier: ${{ needs.triage.outputs.verdict }}
+
+            STEP 1 — Load your reviewer playbook and repo-specific context:
+              a. Read .github/claude-review-guidelines.md (reviewer persona,
+                 quality bar, verdict policy). REQUIRED.
+              b. Read CLAUDE.md at the repo root if it exists (repo-specific
+                 conventions, architecture notes, style rules, do-not-touch
+                 areas). Apply it on top of the shared guidelines.
+
+              Precedence when they conflict:
+                * Repo-specific rules in CLAUDE.md win for repo-specific facts
+                  (e.g. "this module is being deprecated, don't suggest fixes").
+                * The shared guidelines win for review style and verdict policy
+                  (e.g. tone, what NOT to do, APPROVE vs. REQUEST_CHANGES).
+
+            STEP 2 — Gather PR context:
+              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} \
+                --json title,body,baseRefName,headRefName,author,files,additions,deletions
+              gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+
+            STEP 3 — Investigate. Use Read / Grep / Glob to look at surrounding
+            code: callers of changed functions, related tests, adjacent modules.
+            Don't review the diff in isolation. Keep investigation light for
+            trivial changes (haiku-review tier) — but still actually read the
+            full diff before deciding.
+
+            STEP 4 — Decide a verdict:
+              APPROVE          — correct; any feedback is clearly minor.
+              COMMENT          — substantive feedback, nothing blocks merge.
+              REQUEST_CHANGES  — at least one real correctness, security, or
+                                 contract-breaking issue.
+
+              Trivial-change rule (haiku-review tier): after actually reading
+              the diff, if you find no real correctness/security/contract
+              issue, you MUST post APPROVE — do not downgrade to COMMENT over
+              nits or style. Approval is earned by inspecting the diff, never
+              by size alone; still REQUEST_CHANGES if a real issue exists even
+              in a tiny diff.
+
+            STEP 5 — Post a REAL GitHub Review (not a plain comment) so the
+            verdict shows up properly and inline comments anchor to the diff.
+            Use `gh api` directly:
+
+              cat > /tmp/review.json <<'JSON'
+              {
+                "event": "<APPROVE|COMMENT|REQUEST_CHANGES>",
+                "body": "Automated Claude review (${{ needs.triage.outputs.verdict }}) — <APPROVE|COMMENT|REQUEST_CHANGES>.\n\n<markdown summary — 2-5 sentences>\n\n_Reply with `@claude <question>` to follow up._",
+                "comments": [
+                  {"path": "<file>", "line": <int>, "side": "RIGHT", "body": "<markdown>"}
+                ]
+              }
+              JSON
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+                --method POST --input /tmp/review.json
+
+            Rules:
+              - Always post the review (this is the visible "review completed"
+                signal — there is no silent path). The body MUST open with the
+                `Automated Claude review (<tier>) — <verdict>.` status line.
+              - `line` MUST be a line that appears on the new (RIGHT) side of the
+                diff. Use `gh pr diff` as the source of truth; do not invent line
+                numbers — invalid lines cause the API to reject the entire review.
+              - Cap inline comments at 8. Pick the highest-signal issues.
+              - Do not approve if there's an unresolved correctness or security
+                concern.
+              - haiku-review tier: keep the summary short and comments minimal.
+                Aim for at most 3 inline comments unless there's a clear reason.
+
+            STEP 6 — When done, reply to me with exactly one line, e.g.:
+              "Posted REQUEST_CHANGES review with 3 inline comments."
+            Keep it short — the action will post this as a follow-up status
+            comment, and we don't want it to duplicate the review summary.
+
+            LOOP GUARD — end every comment you post (the GitHub Review body
+            AND this status line) with this exact marker on its own final
+            line. The followup job ignores any comment containing it, so the
+            bot can never re-trigger itself:
+              <!-- claude-reviewer -->
+
+  # ============================================================================
+  # Status — guarantees there is never a silent skip. Runs only when the
+  # review job did NOT post (no API key, triage skipped for draft/fork, or a
+  # workflow error) and posts a single plain comment saying so. No secrets,
+  # no LLM, default token only.
+  # ============================================================================
+  status:
+    needs: [triage, review]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      needs.review.result != 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # SECURITY: egress firewall — kept for consistency with every other job
+      # in this file (the convention has no exceptions). This job runs no LLM
+      # and holds no Anthropic key — only the GitHub token for `gh pr comment`
+      # — so its allowlist is just GitHub.
+      - name: Harden runner (egress firewall)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+
+      - name: Post "review did not run" comment
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          PR:   ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          TRIAGE_RESULT: ${{ needs.triage.result }}
+          REVIEW_RESULT: ${{ needs.review.result }}
+          VERDICT: ${{ needs.triage.outputs.verdict }}
+          REASON:  ${{ needs.triage.outputs.reason }}
+        run: |
+          set -euo pipefail
+          if [ "$TRIAGE_RESULT" != "success" ]; then
+            why="triage did not run (ineligible author, or a workflow error)"
+          elif [ "$VERDICT" = "no-key" ]; then
+            why="ANTHROPIC_API_KEY is not configured for this repository"
+          elif [ "$REVIEW_RESULT" = "failure" ]; then
+            why="the review job failed — see the workflow run logs"
+          else
+            why="review did not complete (verdict: ${VERDICT:-none} — ${REASON:-n/a})"
+          fi
+          # `why` is built from our own fixed strings plus the triage reason,
+          # which the triage step already collapses/caps. Pass via stdin
+          # (--body-file -) so nothing re-enters a shell parser.
+          printf '%s\n\n%s\n' \
+            "Automated Claude review did not run: ${why}." \
+            "<!-- claude-reviewer -->" \
+          | gh pr comment "$PR" --repo "$REPO" --body-file -
+
+  # ============================================================================
+  # Follow-up — only path that re-engages Claude after the initial review.
+  # Always uses Sonnet (no triage); humans @-mentioning Claude expect quality.
+  # ============================================================================
+  followup:
+    # author_association gate closes the anonymous public-repo vector: anyone
+    # could otherwise comment `@claude <injection>` and trigger this secrets-
+    # bearing job. Only OWNER/MEMBER/COLLABORATOR may invoke it. The marker
+    # exclusion is the loop guard — the bot stamps every comment it posts with
+    # `<!-- claude-reviewer -->`, so its own messages never re-trigger it
+    # regardless of whether the token's account carries a `[bot]` suffix.
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude') &&
+       !contains(github.event.comment.body, '<!-- claude-reviewer -->') &&
+       !endsWith(github.event.comment.user.login, '[bot]') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !contains(github.event.comment.body, '<!-- claude-reviewer -->') &&
+       !endsWith(github.event.comment.user.login, '[bot]') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # SECURITY: egress firewall — see rationale in the triage job. Primary
+      # exfil control for the Bash + secrets follow-up context.
+      - name: Harden runner (egress firewall)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: true
+          allowed-endpoints: >
+            api.anthropic.com:443
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      # Mirror the triage key guard: skip cleanly (no failed-run noise) when
+      # ANTHROPIC_API_KEY isn't configured for this repo.
+      - name: Require ANTHROPIC_API_KEY
+        id: keycheck
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY not configured; skipping @claude follow-up."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Claude follow-up
+        if: steps.keycheck.outputs.present == 'true'
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.CLAUDE_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          # SECURITY: same Bash/token rationale as the review job above.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 10
+            --allowedTools Read,Grep,Glob,Bash
+          prompt: |
+            You were @-mentioned in a PR thread on ${{ github.repository }}.
+            Load your context:
+              a. Read .github/claude-review-guidelines.md for your reviewer
+                 persona and quality bar. REQUIRED.
+              b. Read CLAUDE.md at the repo root if it exists, for
+                 repo-specific conventions and architecture notes.
+            Repo-specific facts in CLAUDE.md override the shared guidelines
+            when they conflict on repo-specific matters.
+
+            The action provides the triggering comment and thread context. Use
+            `gh pr view` / `gh pr diff` if you need the latest PR state or diff
+            (it may have changed since the initial review — this is a follow-up).
+            Use Read / Grep / Glob to investigate the code if the question
+            requires it.
+
+            If the user is asking a question, answer it concisely and technically
+            in your reply. The action will post your reply in the same thread.
+
+            If the user is explicitly asking for a re-review of the PR (phrases
+            like "please re-review", "review again", "look at the new commits"),
+            run the full review flow from
+            .github/claude-review-guidelines.md and post a real GitHub Review:
+
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews \
+                --method POST --input /tmp/review.json
+
+            with `event`, `body`, and `comments[]` as in the initial review job.
+
+            Be direct. No filler. No emojis.
+
+            LOOP GUARD — end every comment you post with this exact marker on
+            its own final line. The followup job ignores any comment that
+            contains it, so you can never re-trigger yourself:
+              <!-- claude-reviewer -->

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -161,6 +161,8 @@ class AIChatHistoryConfig(NamedTuple):
     ollama_url: str = ""
     grok_api_key: str = ""
     openai_api_key: str = ""
+    anthropic_api_key: str = ""
+    gemini_api_key: str = ""
 
 
 class LokiConfig(NamedTuple):

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -206,6 +206,11 @@ class VaultConfig(NamedTuple):
     global_path: str = "global"
 
 
+class SecurityConfig(NamedTuple):
+    cookie_secret: str = ""
+    step_token_secret: str = ""
+
+
 class PlaidConfig:
     """Parses a standard configuration file for consumption by python code."""
     def __init__(self):
@@ -318,6 +323,11 @@ class PlaidConfig:
     def vault(self) -> VaultConfig:
         vault_config = self.cfg.get('vault', {})
         return VaultConfig(**{k: v for k, v in vault_config.items() if k in VaultConfig._fields})
+
+    @property
+    def security(self) -> SecurityConfig:
+        security_config = self.cfg.get('security', {})
+        return SecurityConfig(**{k: v for k, v in security_config.items() if k in SecurityConfig._fields})
 
     def __str__(self):
         return repr(self)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -195,6 +195,10 @@ SAMPLE_CONFIG = {
         "tenant_path_prefix": "tenants",
         "global_path": "global",
     },
+    "security": {
+        "cookie_secret": "cookie-sign-secret",
+        "step_token_secret": "step-sign-secret",
+    },
 }
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -122,7 +122,9 @@ SAMPLE_CONFIG = {
         "username": "chatuser",
         "password": "chatpass",
         "grok_api_key": "grok-api-secret",
-        "openai_api_key": "openapi-secret"
+        "openai_api_key": "openapi-secret",
+        "anthropic_api_key": "anthropic-secret",
+        "gemini_api_key": "gemini-secret"
     },
     "loki": {
         "host": "loki.example.com",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -35,6 +35,7 @@ OAuthServiceConfig = config_mod.OAuthServiceConfig
 StripeConfig = config_mod.StripeConfig
 EmailConfig = config_mod.EmailConfig
 VaultConfig = config_mod.VaultConfig
+SecurityConfig = config_mod.SecurityConfig
 PlaidConfig = config_mod.PlaidConfig
 
 
@@ -474,6 +475,24 @@ class TestVaultConfig:
         assert vault.enabled is False
         assert vault.url == "http://127.0.0.1:8200"
         assert vault.token == ""
+
+
+# ---------------------------------------------------------------------------
+# SecurityConfig
+# ---------------------------------------------------------------------------
+
+class TestSecurityConfig:
+
+    def test_full_config(self, plaid_config):
+        sec = plaid_config.security
+        assert isinstance(sec, SecurityConfig)
+        assert sec.cookie_secret == "cookie-sign-secret"
+        assert sec.step_token_secret == "step-sign-secret"
+
+    def test_defaults(self, missing_config):
+        sec = missing_config.security
+        assert sec.cookie_secret == ""
+        assert sec.step_token_secret == ""
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -338,10 +338,14 @@ class TestAIChatHistoryConfig:
         assert isinstance(ai, AIChatHistoryConfig)
         assert ai.langchain_db_url == "postgresql://langchain:5432/langchain"
         assert ai.username == "chatuser"
+        assert ai.anthropic_api_key == "anthropic-secret"
+        assert ai.gemini_api_key == "gemini-secret"
 
     def test_defaults(self, missing_config):
         ai = missing_config.ai_chat_history
         assert ai.langchain_db_url == ""
+        assert ai.anthropic_api_key == ""
+        assert ai.gemini_api_key == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a top-level `security:` config section (`cookie_secret`, `step_token_secret`) surfaced as `cfg.security.*`, and `anthropic_api_key`/`gemini_api_key` fields on `ai_chat_history`. Additive, defaults empty, fields filtered like every other section.

**Release as v0.1.58** (setuptools_scm tag-driven) — plaid pins it via PyPI `==` and `cfg.security` AttributeErrors without it.
---
**Part of the per-tenant signing-secrets + ESO-completion effort** — branch `fix/per-tenant-signing-secrets` across plaidcloud-config, plaidcloud-cp-rest, plaid-tenant-infrastructure, plaid.

⚠️ **Release order is load-bearing** (full runbook: plaidcloud-cp-rest `docs/security/coordination-eso-signing-secrets.md`):
1. **plaidcloud-config** → merge + release **v0.1.58**
2. **plaidcloud-cp-rest** → merge, then run `python -m plaidcloud_cp_rest.maintenance.backfill_vault_secrets`
3. **plaid-tenant-infrastructure** → merge; verify every tenant `plaid-config` has non-empty `security.cookie_secret`
4. **plaid** → merge LAST + rolling-restart plaid-rpc

Cutover is one-time/expected: session logout + claude.ai MCP re-auth + ≤1h step-token reissue. Deploy in a low-activity window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)