### PR TITLE
fix(dev-config): add dev security section so local rpc boots

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -79,3 +79,10 @@ superset:
   use_event_handler: false
   username: admin
   password: admin
+security:
+  # Local dev only. In-cluster, cookie_secret / step_token_secret are rendered
+  # from Vault via ESO (external-secret-tenant-config.yaml). A dev config that
+  # sets `tenant.id` otherwise fail-closes in get_cookie_secret(); these
+  # placeholders let the dev rpc boot. NOT real secrets — local sessions only.
+  cookie_secret: dev-only-cookie-secret-not-for-production
+  step_token_secret: dev-only-step-token-secret-not-for-production


### PR DESCRIPTION
## Why

The per-tenant signing-secrets work made `get_cookie_secret()` **fail-closed** when `tenant.id` is set but `security.cookie_secret` is empty (so a provisioned tenant can't silently sign with the public legacy fallback). In-cluster that section is rendered from Vault via ESO — but `dev-config.yaml` (the template local devs pull, `devspace.yaml` curls it into `kubernetes/config.yaml`) has **no `security:` section**. So a local dev config with a `tenant.id` set takes the local rpc **down at boot** with `RuntimeError: security.cookie_secret is unset for provisioned tenant`.

(Surfaced when a dev's local paul-dev rpc wouldn't start after pulling the new code.)

## What

Add a local-dev `security:` block with clearly-non-production placeholder values, consistent with the template's other dev defaults (`postgres/postgres`, `admin/admin`). ESO supplies the real values in-cluster; this just lets the local rpc boot.

```yaml
security:
  cookie_secret: dev-only-cookie-secret-not-for-production
  step_token_secret: dev-only-step-token-secret-not-for-production
```

Validated: the template parses as YAML once `{namespace}` is substituted, and `security.cookie_secret`/`step_token_secret` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)