### PR TITLE
feat(tenant): add client_asset_version to TenantConfig

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -115,6 +115,7 @@ class TenantConfig(NamedTuple):
     stripe_webhook_secret: str = ""
     ramp_client_id: str = ""
     ramp_client_secret: str = ""
+    client_asset_version: str = ""
 
 
 class GlobalConfig(NamedTuple):

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,6 @@ __author__ = "Garrett Bates"
 __copyright__ = "© Copyright 2020-2025, PlaidCloud, Inc"
 __credits__ = ["Garrett Bates"]
 __license__ = "Apache 2.0"
-__version__ = "0.1.61"
 __maintainer__ = "Garrett Bates"
 __email__ = "garrett.bates@tartansolutions.com"
 __status__ = "Development"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -90,6 +90,7 @@ SAMPLE_CONFIG = {
         "app_logo_url": "logo.png",
         "splash_screen_logo_url": "splash.png",
         "superset_logo_url": "superset.png",
+        "client_asset_version": "v-test-123",
         "workflow_run_history": {
             "writer_user": "wfh_writer",
             "writer_password": "wpw",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -246,6 +246,7 @@ class TestTenantConfig:
         assert t.stripe_webhook_secret == "whsec_tenant_test"
         assert t.ramp_client_id == "ramp_id_test"
         assert t.ramp_client_secret == "ramp_secret_test"
+        assert t.client_asset_version == "v-test-123"
         assert t.workflow_run_history == {
             "writer_user": "wfh_writer",
             "writer_password": "wpw",
@@ -268,6 +269,7 @@ class TestTenantConfig:
         assert t.stripe_webhook_secret == ""
         assert t.ramp_client_id == ""
         assert t.ramp_client_secret == ""
+        assert t.client_asset_version == ""
         assert t.workflow_run_history == {}
         assert t.entitlements == {}
 


### PR DESCRIPTION
## Summary

Workstream **A** of [sc-22731](https://app.shortcut.com/plaidcloud/story/22731) — serve the PlaidClient bundle from GCS and retire the per-tenant `client` pods.

- Adds `client_asset_version: str = ""` to `TenantConfig`. This is the per-tenant knob that pins which versioned client bundle a tenant serves. **Default empty** preserves the legacy pod-served path, so this is inert until a tenant opts in — enabling gradual, reversible cutover.
- Removes the stale hardcoded `__version__` from `setup.py`. The package version is derived dynamically from git tags via `setuptools-scm` (`pyproject.toml` `dynamic = ["version"]` + `[tool.setuptools_scm]`); the static string was unused and misleading.

This package is pinned in `plaid` and `PlaidClient`; the new field is consumed by the plaid-rpc shell route (workstream B) and plumbed via `tenantMeta.client_asset_version` in `plaid-tenant-infrastructure` (workstream D). All no-ops until a version is set.

## Testing

- Extended the tenant fixture + `TestTenantConfig` (full-config value + default) — all `TenantConfig` tests pass.
- The 5 failures in `test_env_overrides.py` are **pre-existing on `master`** (confirmed against a clean tree), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)