### PR TITLE
feat(tenant): add client_bucket_serving to TenantConfig

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -116,6 +116,7 @@ class TenantConfig(NamedTuple):
     ramp_client_id: str = ""
     ramp_client_secret: str = ""
     client_asset_version: str = ""
+    client_bucket_serving: bool = False
 
 
 class GlobalConfig(NamedTuple):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -91,6 +91,7 @@ SAMPLE_CONFIG = {
         "splash_screen_logo_url": "splash.png",
         "superset_logo_url": "superset.png",
         "client_asset_version": "v-test-123",
+        "client_bucket_serving": True,
         "workflow_run_history": {
             "writer_user": "wfh_writer",
             "writer_password": "wpw",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -247,6 +247,7 @@ class TestTenantConfig:
         assert t.ramp_client_id == "ramp_id_test"
         assert t.ramp_client_secret == "ramp_secret_test"
         assert t.client_asset_version == "v-test-123"
+        assert t.client_bucket_serving is True
         assert t.workflow_run_history == {
             "writer_user": "wfh_writer",
             "writer_password": "wpw",
@@ -270,6 +271,7 @@ class TestTenantConfig:
         assert t.ramp_client_id == ""
         assert t.ramp_client_secret == ""
         assert t.client_asset_version == ""
+        assert t.client_bucket_serving is False
         assert t.workflow_run_history == {}
         assert t.entitlements == {}
 


### PR DESCRIPTION
Splits **"which bundle"** from **"bucket or pod"**. One field can't carry both.

## Why

CI is about to bump `client_asset_version` on every build so a bucket-served tenant tracks new bundles automatically (without it, migrating a tenant *freezes* its client — bug-fixes is frozen on `d14b058-823-1` right now). But that makes the field **permanently truthy**, and every consumer today reads truthy as *"this tenant is bucket-served"*. The first CI bump would flip the entire fleet at once.

So:

| Field | Owner | Means |
|---|---|---|
| `client_asset_version` | CI, every build | which bundle **if** bucket-serving |
| `client_bucket_serving` (new, default `False`) | control plane, per tenant | bucket or pod |

Default `False` ⇒ nothing changes until a tenant opts in.

## What breaks without it

**`plaid/web/client_validator.py`** gates on `client_asset_version` being set to decide the pinned version is the source of truth *instead of listing client pods*. Once CI bumps it fleet-wide, that branch is always taken — it would never list pods again, and would report clients outdated whenever the image bump had landed but the pods hadn't yet rolled, wedging them into a reload loop. It must gate on the new flag instead.

Same for rpc's client shell route, and for **devspace**: `devspace.yaml` syncs local source *into the client pod* (`labelSelector: {component: client}`), so the pod **is** the dev loop. A dev tenant must keep the pod path regardless of what version CI has published — otherwise `/source` serves the CI bundle from GCS and local edits become invisible.

## Scope

Mirrors `bcc30e6` (which added `client_asset_version`) exactly: the field plus its two test touchpoints. Appended with a default, so the NamedTuple stays backwards-compatible.

`45 passed`.

Part of sc-22731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)