### PR TITLE
sc-23648: add untyped cfg.feature() accessor for undeclared feature flags

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -255,6 +255,11 @@ class PlaidConfig:
         feature_config = self.cfg.get('features', {})
         return FeatureConfig(**{k: v for k, v in feature_config.items() if k in FeatureConfig._fields})
 
+    def feature(self, name: str, default=False):
+        """Read a feature flag by name, including flags not declared on FeatureConfig
+        (e.g. UI-set flags merged in via PLAID_CFG00features00<name> env overrides)."""
+        return self.cfg.get('features', {}).get(name, default)
+
     @property
     def keycloak(self) -> KeycloakConfig:
         keycloak_config = self.cfg.get('keycloak', {})

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -203,6 +203,26 @@ class TestFeatureConfig:
         assert feat.enable_cors is False
         assert feat.flashback is True
 
+    def test_feature_reads_undeclared_flag(self, plaid_config):
+        plaid_config.cfg["features"]["experimental_x"] = True
+        assert plaid_config.feature("experimental_x") is True
+        assert not hasattr(plaid_config.features, "experimental_x")
+
+    def test_feature_reads_declared_field(self, plaid_config):
+        assert plaid_config.feature("flashback") is False
+        assert plaid_config.feature("flashback") == plaid_config.features.flashback
+
+    def test_feature_default_when_absent(self, missing_config):
+        assert missing_config.feature("nope") is False
+        assert missing_config.feature("nope", "d") == "d"
+
+    def test_feature_env_override_end_to_end(self, config_file, monkeypatch):
+        mod = sys.modules["plaidcloud.config.config"]
+        monkeypatch.setattr(mod, "CONFIG_PATH", config_file)
+        monkeypatch.setenv("PLAID_CFG00features00new_flag", "true")
+        cfg = PlaidConfig()
+        assert cfg.feature("new_flag") is True
+
 
 # ---------------------------------------------------------------------------
 # KeycloakConfig


### PR DESCRIPTION
## Symptom
Per-tenant feature flags settable from the Control Plane UI are delivered as env vars (`PLAID_CFG00features00<name>`) and merged into `cfg.cfg['features']` by `_apply_env_overrides`. But a flag whose name isn't a declared field is **invisible** on `cfg.features` — every new flag would otherwise need a plaidcloud-config PR + release plus consumer pin bumps before it could be read anywhere.

## Root cause
`config.py:254-256` — the typed `features` property builds `FeatureConfig(**{k:v ... if k in FeatureConfig._fields})`, dropping any key not declared on `FeatureConfig` (`config.py:129-138`), even though the merge already happened.

## Change
Add an untyped accessor next to the property (`python/plaidcloud/config/config.py`):

```python
def feature(self, name: str, default=False):
    return self.cfg.get('features', {}).get(name, default)
```

Purely additive — typed `cfg.features.*` fields keep working unchanged. Scope deliberately limited to the `features` section (per story Notes); not generalised to an arbitrary-section reader.

## Tests (`python/tests/test_config.py`)
- undeclared flag readable via `feature()` — and confirmed absent from typed `.features`
- declared field still resolves via `feature()` (cross-checked against `.features.flashback`)
- default returned when absent
- env-override end to end: `setenv('PLAID_CFG00features00new_flag','true')` then `PlaidConfig()` → `.feature('new_flag') is True`

## Verification
`cd python && pip install -e ".[test]" && pytest tests/ -q` → **98 passed**. New tests fail-before on master with `AttributeError: no attribute 'feature'`. `pylint -E plaidcloud` clean; no new warnings on changed lines. No coverage gate.

Release tag + consumer pin bumps are separate human/epic steps (not in this PR).

Story: https://app.shortcut.com/plaidcloud/story/23648

🤖 Generated with [Claude Code](https://claude.com/claude-code)