### PR TITLE
Retire FeatureConfig and the features property (sc-24012)

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -14,16 +14,8 @@ environment:
   designation: dev
   tempdir: /tmp/
   verify_ssl: false
-features:
-  async_copy: true
-  backward_compatible_state: true
-  decrypted_accounts: true
-  enable_cors: false
-  fast_clean_csv: true
-  flashback: true
-  google_login: true
-  table_update_recreate: true
-  use_numeric_cast: true
+# No `features:` block by default — flags are per-tenant and undeclared; read them
+# with cfg.feature('name', default). Add the key here only to exercise one locally.
 rabbitmq:
   hostname: plaid-rabbitmq
   port: 5672

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -126,18 +126,6 @@ class GlobalConfig(NamedTuple):
     db_host: str = ""
 
 
-class FeatureConfig(NamedTuple):
-    async_copy: bool = True
-    backward_compatible_state: bool = True
-    decrypted_accounts: bool = True
-    enable_cors: bool = False
-    fast_clean_csv: bool = True
-    flashback: bool = True
-    google_login: bool = True
-    table_update_recreate: bool = True
-    use_numeric_cast: bool = True
-
-
 class ServiceConfig(NamedTuple):
     auth: str = "http://plaid-auth.plaid"
     client: str = "http://plaid-client.plaid"
@@ -250,15 +238,11 @@ class PlaidConfig:
             ec = ec._replace(hostname=ec.hostnames[0])
         return ec
 
-    @property
-    def features(self) -> FeatureConfig:
-        feature_config = self.cfg.get('features', {})
-        return FeatureConfig(**{k: v for k, v in feature_config.items() if k in FeatureConfig._fields})
-
     def feature(self, name: str, default=False):
-        """Read a feature flag by name, including flags not declared on FeatureConfig
-        (e.g. UI-set flags merged in via PLAID_CFG00features00<name> env overrides)."""
-        return self.cfg.get('features', {}).get(name, default)
+        """Read a feature flag by name. Flags are not declared anywhere — they are whatever
+        the tenant's config carries, including UI-set flags merged in via
+        PLAID_CFG00features00<name> env overrides."""
+        return (self.cfg.get('features') or {}).get(name, default)
 
     @property
     def keycloak(self) -> KeycloakConfig:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -37,15 +37,8 @@ SAMPLE_CONFIG = {
         "workflow_image": "plaid/workflow:latest",
     },
     "features": {
-        "async_copy": False,
-        "backward_compatible_state": False,
-        "decrypted_accounts": False,
-        "enable_cors": True,
-        "fast_clean_csv": False,
-        "flashback": False,
-        "google_login": False,
-        "table_update_recreate": False,
-        "use_numeric_cast": False,
+        "sample_flag_on": True,
+        "sample_flag_off": False,
     },
     "keycloak": {
         "url": "https://auth.example.com",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -20,7 +20,6 @@ config_mod = sys.modules['plaidcloud.config.config']
 
 DatabaseConfig = config_mod.DatabaseConfig
 EnvironmentConfig = config_mod.EnvironmentConfig
-FeatureConfig = config_mod.FeatureConfig
 KeycloakConfig = config_mod.KeycloakConfig
 TenantConfig = config_mod.TenantConfig
 GlobalConfig = config_mod.GlobalConfig
@@ -185,38 +184,33 @@ class TestEnvironmentConfig:
 
 
 # ---------------------------------------------------------------------------
-# FeatureConfig
+# Feature flags
 # ---------------------------------------------------------------------------
 
-class TestFeatureConfig:
+class TestFeatureFlags:
 
-    def test_full_config(self, plaid_config):
-        feat = plaid_config.features
-        assert isinstance(feat, FeatureConfig)
-        assert feat.async_copy is False
-        assert feat.enable_cors is True
-        assert feat.flashback is False
+    def test_reads_flags_from_config(self, plaid_config):
+        assert plaid_config.feature("sample_flag_on") is True
+        assert plaid_config.feature("sample_flag_off") is False
 
-    def test_defaults(self, missing_config):
-        feat = missing_config.features
-        assert feat.async_copy is True
-        assert feat.enable_cors is False
-        assert feat.flashback is True
-
-    def test_feature_reads_undeclared_flag(self, plaid_config):
+    def test_reads_flag_added_at_runtime(self, plaid_config):
         plaid_config.cfg["features"]["experimental_x"] = True
         assert plaid_config.feature("experimental_x") is True
-        assert not hasattr(plaid_config.features, "experimental_x")
 
-    def test_feature_reads_declared_field(self, plaid_config):
-        assert plaid_config.feature("flashback") is False
-        assert plaid_config.feature("flashback") == plaid_config.features.flashback
-
-    def test_feature_default_when_absent(self, missing_config):
+    def test_default_when_absent(self, missing_config):
         assert missing_config.feature("nope") is False
         assert missing_config.feature("nope", "d") == "d"
 
-    def test_feature_env_override_end_to_end(self, config_file, monkeypatch):
+    def test_default_when_features_block_empty(self, tmp_path, monkeypatch):
+        """A `features:` key rendered with no children loads as None, not {}, so the
+        default must survive an explicitly empty block as well as a missing one."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("features:\n")
+        mod = sys.modules["plaidcloud.config.config"]
+        monkeypatch.setattr(mod, "CONFIG_PATH", str(config_path))
+        assert PlaidConfig().feature("anything", "fallback") == "fallback"
+
+    def test_env_override_end_to_end(self, config_file, monkeypatch):
         mod = sys.modules["plaidcloud.config.config"]
         monkeypatch.setattr(mod, "CONFIG_PATH", config_file)
         monkeypatch.setenv("PLAID_CFG00features00new_flag", "true")

--- a/python/tests/test_env_overrides.py
+++ b/python/tests/test_env_overrides.py
@@ -40,12 +40,12 @@ def test_add_new_nested_path(plaid_config, clean_env):
 
 
 def test_yaml_type_coercion(plaid_config, clean_env):
-    clean_env.setenv("PLAID_CFG00features00async_copy", "false")
+    clean_env.setenv("PLAID_CFG00features00sample_flag_on", "false")
     clean_env.setenv("PLAID_CFG00database00port", "6543")
     cfg = PlaidConfig()
-    assert cfg.cfg['features']['async_copy'] is False
+    assert cfg.cfg['features']['sample_flag_on'] is False
     assert cfg.cfg['database']['port'] == 6543
-    assert cfg.features.async_copy is False
+    assert cfg.feature('sample_flag_on') is False
     assert cfg.database.port == 6543
 
 


### PR DESCRIPTION
Closes the `plaidcloud-config` half of [sc-24012](https://app.shortcut.com/plaidcloud/story/24012).

`FeatureConfig` and `PlaidConfig.features` are gone. `cfg.feature(name, default)` is now the only way to read a flag, which means a flag a tenant sets is a flag a consumer can read — no typed NamedTuple silently dropping anything it wasn't taught about.

## Changes

- **`config.py`** — delete `FeatureConfig` (9 fields) and the `features` property.
- **`config.py`** — `feature()` now treats a `features:` key with no children as empty. YAML loads that as `None`, and `.get('features', {})` doesn't help because the key *is* present, so the old code would have thrown `AttributeError` instead of returning the default. This matters as soon as the block starts being removed from the helm templates. Covered by a new test.
- **`dev-config.yaml`** — drop the nine flags.
- **tests** — `TestFeatureConfig` → `TestFeatureFlags`; fixtures use generic flag names, since nothing declares flag names any more.

## Verification

- No code in any sibling repo imports `FeatureConfig` — only stale planning notes in a couple of plaid worktrees (`KEDA_WORKERS.md` suggests *promoting* a flag to `FeatureConfig`; that advice is now obsolete).
- The six "read nowhere" flags are genuinely unread. Note that `fast_clean_csv` is *also* a function in `plaid/app/analyze/utility/import_tools.py:578`, called unconditionally — a naive grep hits it, but it's not a flag read.
- `dev-config.yaml` is fetched live from `master` (unpinned) by ~10 repos' `devspace.yaml`. Removing the block is still a behavioural no-op: all nine values in that file were identical to the `FeatureConfig` defaults, so a dev container on an older plaidcloud-config sees no change.
- Test suite: 91 passed, 6 failed — the same 6 that fail on `master`. All Windows-only: `os.environ` upper-cases keys, so `PLAID_CFG00…` overrides never match the lower-case path lookup in `_apply_env_overrides`. Unrelated to this PR, but it means the env-override path can't be tested locally on Windows.

## Merge order

This removes `cfg.features`, which plaid still reads at 14 sites. plaid pins plaidcloud-config via PyPI `==`, so nothing breaks until that pin moves — but the plaid half should land first, and the release tag is being held until it does.

## Follow-ups for the rest of the story

Both raised on sc-24012 and now reflected in the story description.

**`flashback` is retiring too.** Five tenants still carry `flashback: false` (`arvest`, `asp-solution`, `evoque-partners`, `testcc1`, `testcc2`). Decided 2026-08-06: flashback applies to everyone now, so it retires with the other eight rather than staying per-tenant.

**The `features:` block renders from three templates, not one.** The story originally named only `configmap-tenant.yaml`; step 3 now covers all three, since the ESO one is the path actually serving tenants post-cutover:

| Template | Line |
|---|---|
| `tenants/templates/external-secret-tenant-config.yaml` | 157-166 |
| `tenants/templates/configmap-tenant.yaml` | 28-37 |
| `controlplane/templates/configmap.yaml` | 35-44 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
