### PR TITLE
feat(config): declare the tenant lakehouse collection (sc-23158 step 1)

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -55,6 +55,30 @@ class DatabaseConfig(NamedTuple):
     lakekeeper_token: str = ""
 
 
+class LakehouseConfig(NamedTuple):
+    """One of the warehouses a tenant has (sc-23158).
+
+    Mirrors the control plane's Lakehouse record field for field. `id` is assigned by the
+    control plane, opaque and immutable — it is the primary key a project's `lakehouse_id`
+    names, deliberately not derived from the coordinates, which are mutable.
+
+    ⚠️ `credential_ref` is the NAME of a Vault key, never a credential. Nothing in this
+    library resolves it; a caller that wants the password reads that key out of the tenant's
+    Vault entry.
+
+    `catalog` and `compute` are nullable by design: the control plane owns neither, and a
+    default here would be a stale copy of somebody else's.
+    """
+    id: str = ""
+    name: str = ""
+    engine: str = ""
+    status: str = ""
+    coordinates: dict = {}
+    catalog: dict | None = None
+    compute: dict | None = None
+    credential_ref: str = ""
+
+
 class EnvironmentConfig(NamedTuple):
     hostname: str = "plaidcloud.io"
     hostnames: list = ["plaidcloud.io"]
@@ -228,6 +252,30 @@ class PlaidConfig:
     def database(self) -> DatabaseConfig:
         db_config = self.cfg.get('database', {})
         return DatabaseConfig(**{k: v for k, v in db_config.items() if k in DatabaseConfig._fields})
+
+    @property
+    def lakehouses(self) -> list[LakehouseConfig]:
+        """Every lakehouse this tenant has, in the order the control plane recorded them.
+
+        Empty on every tenant whose values file predates the render — an absent collection is
+        not an error, it is a tenant that has not been republished yet.
+        """
+        db_config = self.cfg.get('database') or {}
+        return [
+            LakehouseConfig(**{k: v for k, v in lakehouse.items() if k in LakehouseConfig._fields})
+            for lakehouse in db_config.get('lakehouses') or []
+        ]
+
+    @property
+    def default_lakehouse_id(self) -> str:
+        """The id newly created projects bind to. Empty when the tenant has no collection.
+
+        An id, not a record: a project stores this id, and resolving it against `lakehouses`
+        is the caller's business. Matching by id is the only correct resolution — with one
+        lakehouse a "first in the list" fallback is indistinguishable from a real answer and
+        stops being right exactly when a second one appears.
+        """
+        return (self.cfg.get('database') or {}).get('default_lakehouse_id') or ""
 
     @property
     def environment(self) -> EnvironmentConfig:

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -555,3 +555,123 @@ class TestRedisViaPlaidConfig:
         rc = plaid_config.redis
         assert isinstance(rc, RedisConfig)
         assert "session" in rc.urls
+
+
+# ---------------------------------------------------------------------------
+# LakehouseConfig (sc-23158)
+# ---------------------------------------------------------------------------
+
+# A rendered `database:` block exactly as the tenant chart emits it once cp-rest
+# writes the collection: the single warehouse a tenant runs today, plus a second
+# one so ordering and id-matching are actually exercised.
+LAKEHOUSE_CFG = {
+    "database": {
+        "hostname": "starrocks-fe-service",
+        "port": 9030,
+        "superuser": "root",
+        "password": "pw",
+        "system": "starrocks",
+        "default_lakehouse_id": "lh-2222",
+        "lakehouses": [
+            {
+                "id": "lh-1111",
+                "name": "Databend",
+                "engine": "databend",
+                "status": "retired",
+                "coordinates": {"hostname": "plaid-databend-query", "port": 8000, "database_name": ""},
+                "catalog": None,
+                "compute": None,
+                "credential_ref": "lakehouse_admin_password",
+            },
+            {
+                "id": "lh-2222",
+                "name": "StarRocks",
+                "engine": "starrocks",
+                "status": "active",
+                "coordinates": {"hostname": "starrocks-fe-service", "port": 9030, "database_name": ""},
+                "catalog": None,
+                "compute": None,
+                "credential_ref": "lakehouse_admin_password",
+            },
+        ],
+    }
+}
+
+
+def _config_from(tmp_path, monkeypatch, cfg):
+    config_path = tmp_path / "cfg.yaml"
+    config_path.write_text(yaml.dump(cfg))
+    mod = sys.modules['plaidcloud.config.config']
+    monkeypatch.setattr(mod, "CONFIG_PATH", str(config_path))
+    return PlaidConfig()
+
+
+class TestLakehouseCollectionIsInertUntilDeclared:
+    """The property the rollout order rests on: a `lakehouses:` block can appear in a rendered
+    config.yaml before anything reads it, because DatabaseConfig filters keys it does not
+    declare. Without this, a values render landing ahead of a config-library bump would raise
+    TypeError inside `cfg.database` in every plaid pod on the tenant."""
+
+    def test_database_still_parses_with_the_collection_present(self, tmp_path, monkeypatch):
+        db = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).database
+        assert db.hostname == "starrocks-fe-service"
+        assert db.system == "starrocks"
+
+    def test_the_collection_is_not_a_database_field(self, tmp_path, monkeypatch):
+        # Read through `lakehouses` / `default_lakehouse_id`, never `cfg.database`.
+        db = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).database
+        assert "lakehouses" not in db._fields
+        assert "default_lakehouse_id" not in db._fields
+
+
+class TestLakehouses:
+
+    def test_parses_every_modelled_field(self, tmp_path, monkeypatch):
+        lakehouses = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses
+        assert [lakehouse.id for lakehouse in lakehouses] == ["lh-1111", "lh-2222"]
+        starrocks = lakehouses[1]
+        assert isinstance(starrocks, config_mod.LakehouseConfig)
+        assert starrocks.name == "StarRocks"
+        assert starrocks.engine == "starrocks"
+        assert starrocks.status == "active"
+        assert starrocks.coordinates == {
+            "hostname": "starrocks-fe-service", "port": 9030, "database_name": ""}
+        assert starrocks.catalog is None
+        assert starrocks.compute is None
+        assert starrocks.credential_ref == "lakehouse_admin_password"
+
+    def test_absent_collection_is_empty_not_an_error(self, missing_config, plaid_config):
+        # A tenant that has not been republished has no collection. Not a failure.
+        assert missing_config.lakehouses == []
+        assert plaid_config.lakehouses == []
+
+    def test_extra_keys_ignored(self, tmp_path, monkeypatch):
+        # Same forward-compatibility as every other block: the control plane may add a field
+        # before this library declares it.
+        cfg = {"database": {"lakehouses": [{"id": "lh-1", "role": "primary"}]}}
+        lakehouse, = _config_from(tmp_path, monkeypatch, cfg).lakehouses
+        assert lakehouse.id == "lh-1"
+        assert not hasattr(lakehouse, "role")
+
+    def test_credential_ref_is_a_key_name_not_a_credential(self, tmp_path, monkeypatch):
+        # Nothing here resolves the ref, and no field carries a secret — the record is safe to
+        # commit to the values file in Git, which is exactly where it comes from.
+        lakehouses = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses
+        assert all(lakehouse.credential_ref == "lakehouse_admin_password" for lakehouse in lakehouses)
+        assert "password" not in config_mod.LakehouseConfig._fields
+
+
+class TestDefaultLakehouseId:
+
+    def test_reads_the_id(self, tmp_path, monkeypatch):
+        assert _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).default_lakehouse_id == "lh-2222"
+
+    def test_empty_when_absent(self, missing_config, plaid_config):
+        assert missing_config.default_lakehouse_id == ""
+        assert plaid_config.default_lakehouse_id == ""
+
+    def test_is_not_the_first_lakehouse(self, tmp_path, monkeypatch):
+        # A "first in the list" fallback is indistinguishable from a correct answer while a
+        # tenant has one lakehouse, and silently wrong the moment it has two.
+        cfg = {"database": {"lakehouses": [{"id": "lh-1"}, {"id": "lh-2"}]}}
+        assert _config_from(tmp_path, monkeypatch, cfg).default_lakehouse_id == ""


### PR DESCRIPTION
## sc-23158 — **step 1 of 3**: declare the collection

The lakehouse work lands in three steps, each inert until the next:

| | | |
|---|---|---|
| **1** | **plaidcloud-config — declare the collection so it can be parsed** | **this PR** |
| 2 | cp-rest + tenant chart emit it into the rendered tenant config | PlaidCloud/plaidcloud-cp-rest#384 + PlaidCloud/plaid-tenant-infrastructure#933 |
| 3 | plaid consumes it and the `lakehouse-pre-control-plane` sentinel retires | not yet |

`cfg.lakehouses` → `list[LakehouseConfig]` and `cfg.default_lakehouse_id` → `str`, reading
`database.lakehouses[]` and `database.default_lakehouse_id`. `LakehouseConfig` mirrors the
control plane's `Lakehouse` record (cp-rest #383) field for field.

### What makes it inert

**Nothing populates these and nothing reads them.** No rendered `config.yaml` on the fleet
carries a `lakehouses:` key today, so `cfg.lakehouses` is `[]` and `cfg.default_lakehouse_id`
is `''` on all 32 tenants. No existing property changes; `DatabaseConfig` is untouched.

The rollout order rests on a claim that is now **verified rather than assumed**: `DatabaseConfig`
filters keys it does not declare (`{k: v for k, v in db_config.items() if k in
DatabaseConfig._fields}`), so a `lakehouses:` block reaching a pod running an *older*
plaidcloud-config is dropped by that filter instead of raising `TypeError` out of `cfg.database`
— which would take down every plaid pod on the tenant. Executed both ways:

- new lib, new `config.yaml` (extracted from a real `helm template` of the pwc tenant chart, ESO
  placeholders substituted) → `cfg.database.system == 'starrocks'`, one `LakehouseConfig` parsed.
- **`origin/master` lib, same `config.yaml`** → `cfg.database.system == 'starrocks'`, no error, no
  `lakehouses` attribute.

So this PR is not actually a prerequisite for step 2 — it just makes step 2 useful.

### Notes

- **`credential_ref` is the NAME of a Vault key, never a credential.** Nothing here resolves it and
  no field on the record can hold a value, so a record is safe in a Git-committed values file —
  which is exactly where it comes from.
- **`default_lakehouse_id` is an id, not a record, and never falls back to the first lakehouse.**
  With one lakehouse a "first in the list" fallback is indistinguishable from a correct answer and
  stops being correct exactly when a second one appears. Pinned by a test.
- `catalog` / `compute` are nullable: the control plane owns neither, and a default here would be a
  stale copy of the tenant chart's.

### Tests

97 → **106 passed, 0 skipped** (+9). `pylint -E` clean. Null controls run: declaring `lakehouses`
on `DatabaseConfig` reds the inertness test; a first-in-list fallback for the default reds two.
