### PR TITLE
feat(config): make a LakehouseConfig connectable (sc-23158 step 1)

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -151,7 +151,8 @@ _FIXED_PRINCIPAL = {'databricks': 'token'}
 #: class default is already '' — so that a change to `DatabaseConfig`'s defaults cannot
 #: silently re-fabricate one of them.
 _NO_INHERITANCE = DatabaseConfig(hostname="", port=None, superuser="", password="", system="",
-                                 iceberg_catalog="", lakekeeper_url="", lakekeeper_warehouse="")
+                                 iceberg_catalog="", lakekeeper_url="", lakekeeper_warehouse="",
+                                 lakekeeper_token="")
 
 
 def resolve_lakehouse(lakehouse: LakehouseConfig, tenant_default: DatabaseConfig,

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -11,6 +11,7 @@ __email__ = "garrett@plaidcloud.com"
 """Loads the configuration file used by plaid apps in kubernetes."""
 import logging
 import os
+import re
 import yaml
 from typing import NamedTuple
 from plaidcloud.config.redis import RedisConfig
@@ -21,6 +22,10 @@ ENV_OVERRIDE_PREFIX = 'PLAID_CFG'
 ENV_OVERRIDE_SEP = '00'
 
 logger = logging.getLogger(__name__)
+
+#: (lakehouse id, undeclared keys) already reported by `PlaidConfig.lakehouses`. Process-wide
+#: because the warning describes the config file, which does not change under a running pod.
+_WARNED_UNDECLARED = set()
 
 
 def _apply_env_overrides(cfg: dict) -> None:
@@ -56,6 +61,12 @@ class DatabaseConfig(NamedTuple):
     lakekeeper_url: str = "http://lakekeeper:8181"
     lakekeeper_warehouse: str = ""
     lakekeeper_token: str = ""
+    # The control-plane id of the lakehouse this describes, for records `resolve_lakehouse`
+    # builds. Empty on `cfg.database`, which is the chart's block and names no lakehouse — and
+    # empty is what plaid's `assigned_lakehouse_id` already reads for "unassigned". Without it
+    # a resolved record cannot be matched back to a project's `lakehouse_id`, so on a tenant
+    # with two lakehouses every binding fails to resolve.
+    lakehouse_id: str = ""
 
 
 class LakehouseConfig(NamedTuple):
@@ -75,10 +86,10 @@ class LakehouseConfig(NamedTuple):
     ⚠️ `coordinates`, `catalog` and `compute` stay NESTED, and are unpacked in exactly one
     place — `resolve_lakehouse`. They are not free-form: they are cp-rest's
     `LakehouseCoordinates` / `LakehouseCatalog` / `LakehouseCompute` models
-    (`router/tenant.py`), which is the shape the values file actually carries. Promoting
-    their members to top-level fields here would not flatten the record, it would stop
-    parsing it — a rendered `coordinates:` block would match no declared field and every
-    lakehouse would resolve to an empty hostname.
+    (`router/tenant.py`), which is the shape the values file carries. Top-level twins would
+    parse — they would just sit at their defaults, unfed by any rendered record — so the
+    reason not to add them is that they would be a second, always-empty answer to a question
+    `coordinates` already answers, not that the record would fail to load.
     """
     id: str = ""
     name: str = ""
@@ -98,67 +109,92 @@ class LakehouseConfig(NamedTuple):
     credential_ref: str = ""
 
 
-#: The `catalog` members that are `DatabaseConfig` fields. Omitted rather than passed empty
-#: when the record does not carry them: cp-rest sets `catalog: None` on the warehouses it
-#: provisions precisely because it does not own these coordinates, so the answer there is
-#: `DatabaseConfig`'s own defaults, not `''`.
-_CATALOG_FIELDS = ('iceberg_catalog', 'lakekeeper_url', 'lakekeeper_warehouse')
+#: A customer-owned lakehouse, identified as cp-rest identifies one
+#: (`lakehouse_tools.is_credential_ref`): its credential lives in the per-lakehouse vault-only
+#: namespace. Anything else is PlaidCloud-provisioned. Keyed on the credential ref rather than
+#: `engine` because that is what cp-rest's own `reconcile_default_lakehouse` keys on; an engine
+#: test would misfile the first customer StarRocks.
+_CUSTOMER_CREDENTIAL_REF = re.compile(r'^lakehouse_lh-[0-9a-f]{32}_password$')
+
+#: What a customer record inherits: nothing. The empty `superuser` is what makes a missing
+#: principal raise, and the class-default Iceberg coordinates are right because a warehouse
+#: PlaidCloud does not run has no tenant Lakekeeper.
+_NO_INHERITANCE = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
 
 
-def resolve_lakehouse(lakehouse: LakehouseConfig, password: str) -> DatabaseConfig:
-    """The connectable form of one lakehouse: a `DatabaseConfig`, ready for
-    `plaid.core.data.orm.build_lakehouse_dsns`.
+def resolve_lakehouse(lakehouse: LakehouseConfig, tenant_default: DatabaseConfig,
+                      password: str) -> DatabaseConfig:
+    """The connectable form of one lakehouse, for `orm.build_lakehouse_dsns`.
 
-    A `DatabaseConfig` and not a widened `LakehouseConfig`, because two consumers read the
-    type and not just the attributes. `orm.build_lakehouse_dsns` reads `system`, `superuser`,
-    `hostname`, `port`, `database_name`, `query_params` and `password` under those names; and
-    `orm.lakehouse_fingerprint` — the engine-cache key — iterates `DatabaseConfig._fields`
-    with `getattr(..., None)`, so any other type drops whatever it happens not to declare out
-    of the key and lets two lakehouses share one engine. `database_tools`' Iceberg half reads
-    `iceberg_catalog` / `lakekeeper_*` off the same record, again under these names.
+    A `DatabaseConfig` because the TYPE is read: `orm.lakehouse_fingerprint` builds the
+    engine-cache key from `DatabaseConfig._fields`, so another type drops fields out of the
+    key and lets two lakehouses share one engine.
 
-    `password` is an ARGUMENT because it is not in the record and must not be: a lakehouse
-    names its credential with `credential_ref`, a Vault key name, and nothing in this library
-    resolves it. The caller supplies the credential it read.
+    `tenant_default` is `cfg.database`, and it is the inheritance base ONLY for a
+    PlaidCloud-provisioned record — which re-describes the warehouse `cfg.database` already
+    addresses. `mint_tenant_lakehouse` emits no `superuser` and `catalog: None`, so without
+    that a fleet-standard record resolves to a blank principal and to the class-default
+    `lakekeeper_url`, which names no Service in a tenant namespace. A customer record inherits
+    nothing: falling back to the tenant's own warehouse for one PlaidCloud does not run is the
+    "answers for the wrong warehouse while looking like it worked" failure.
 
-    `cloud_url` is left at its default on purpose — the legacy shared-Postgres catalog is one
-    per tenant, is read from `cfg.database` by `orm.build_shared_dsns`, and is not a lakehouse
-    coordinate. `lakekeeper_token` is left at its default for the duller reason that the
-    control plane's record has no field for it; a StarRocks lakehouse whose Lakekeeper needs a
-    token cannot get one through here yet.
+    `password` is an argument: the record names a Vault key, and nothing here resolves it.
 
-    Refuses a disabled lakehouse rather than returning something connectable: this is the only
-    seam in this library where that flag can bite, and a kill switch nothing reads is
-    decoration. `status` is deliberately NOT refused — `retired` blocks new project bindings
-    (cp-rest `LAKEHOUSE_STATUSES`), it does not stop the projects already there from reading.
+    Refuses a disabled lakehouse, and one that names no warehouse at all. `status` is NOT
+    refused — `provisioning` is what `create_tenant` mints and what bootstrap must connect to
+    in order to build the warehouse, and `retired` still serves the projects already on it.
     """
     if lakehouse.disabled:
         raise ValueError(
             f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) is disabled and cannot be connected to'
         )
     coordinates = lakehouse.coordinates or {}
+    hostname = coordinates.get('hostname') or ''
+    if not lakehouse.engine or not hostname:
+        raise ValueError(
+            f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) names no warehouse: '
+            f'engine={lakehouse.engine!r}, coordinates.hostname={hostname!r}'
+        )
+
+    inherited = _NO_INHERITANCE if is_customer_lakehouse(lakehouse) else tenant_default
+    superuser = lakehouse.superuser or inherited.superuser
+    if not superuser:
+        raise ValueError(
+            f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) has no superuser and is not '
+            'PlaidCloud-provisioned, so there is no tenant default to fall back to'
+        )
     catalog = lakehouse.catalog or {}
-    compute = lakehouse.compute or {}
     return DatabaseConfig(
-        hostname=coordinates.get('hostname', ''),
+        lakehouse_id=lakehouse.id,
+        hostname=hostname,
         # None for an engine whose URL takes no port (Snowflake); `URL.create` accepts it.
         port=coordinates.get('port'),
-        superuser=lakehouse.superuser,
+        superuser=superuser,
         password=password,
         # `engine` and `system` range over the same words — starrocks, databend, snowflake,
-        # databricks (`lakehouse_tools.LAKEHOUSE_ENGINES`, and the chart renders
-        # `system: {{ externalDatabase.protocol }}`).
+        # databricks — and the chart renders `system: {{ externalDatabase.protocol }}`.
         system=lakehouse.engine,
-        # Passed through as the control plane recorded it, including ''. The in-cluster
-        # engines render an empty database name, and substituting `DatabaseConfig`'s
-        # 'plaid_data' default would be this library guessing a warehouse.
+        # As recorded, including ''. The in-cluster engines render an empty database name, so
+        # substituting 'plaid_data' would be this library guessing.
         database_name=coordinates.get('database_name') or '',
-        # Compute selection rides the DSN query string: Snowflake picks it with
-        # warehouse/role, Databricks with http_path. Unset members serialize as null and
-        # would otherwise render as literal 'None' in the URL.
-        query_params={k: v for k, v in compute.items() if v is not None},
-        **{k: catalog[k] for k in _CATALOG_FIELDS if catalog.get(k)},
+        # Compute rides the DSN query string. Empty is absent, as in cp-rest's
+        # `missing_connection_fields`; forwarding it renders `?role=`.
+        query_params={k: v for k, v in (lakehouse.compute or {}).items() if v},
+        # `.get(k, default)` and not truthiness: an operator setting these to '' is saying
+        # this lakehouse has no Iceberg half, and that has to survive.
+        iceberg_catalog=catalog.get('iceberg_catalog', inherited.iceberg_catalog),
+        lakekeeper_url=catalog.get('lakekeeper_url', inherited.lakekeeper_url),
+        lakekeeper_warehouse=catalog.get('lakekeeper_warehouse', inherited.lakekeeper_warehouse),
+        # `LakehouseCatalog` has no token field, so inheritance is the only source.
+        lakekeeper_token=inherited.lakekeeper_token,
+        # cloud_url is deliberately absent: one shared-Postgres catalog per tenant, read from
+        # `cfg.database` by `orm.build_shared_dsns`, never a lakehouse coordinate.
     )
+
+
+def is_customer_lakehouse(lakehouse: LakehouseConfig) -> bool:
+    """Whether the customer owns this warehouse, rather than PlaidCloud provisioning it."""
+    return bool(_CUSTOMER_CREDENTIAL_REF.fullmatch(lakehouse.credential_ref or ''))
 
 
 class EnvironmentConfig(NamedTuple):
@@ -342,27 +378,27 @@ class PlaidConfig:
         Empty on every tenant whose values file predates the render — an absent collection is
         not an error, it is a tenant that has not been republished yet.
 
-        Undeclared keys are still dropped rather than raised on, because a values render
-        landing ahead of a library bump must not TypeError inside every plaid pod on the
-        tenant — that rollout order is what `LakehouseConfig` exists ahead of its consumers
-        for. But the drop is LOGGED. Silence is what let cp-rest's `disabled` and `superuser`
-        disappear here for a whole release: a record said a warehouse was switched off, this
-        filter discarded the key, and the result was a lakehouse that read as enabled with
-        nothing anywhere saying otherwise.
+        Undeclared keys are dropped rather than raised on, so a values render can land ahead
+        of a library bump without a TypeError in every plaid pod (the rollout order
+        `test_extra_keys_ignored` pins). But the drop is LOGGED, once per record-and-key-set:
+        this is a property that plaid re-reads on every project resolution, and a per-read
+        warning floods the very window it exists to report. Silence is what let `disabled` and
+        `superuser` disappear here; a flood is the same as silence.
 
-        Only lakehouse records are checked. Every other block filters undeclared keys
-        deliberately and constantly — `database:` alone carries `lakehouses` and
-        `default_lakehouse_id`, which `DatabaseConfig` drops by design — so a library-wide
-        warning would be noise on every pod start, and noise is the same as silence.
+        Lakehouse records only — every other block drops undeclared keys by design
+        (`database:` carries `lakehouses` and `default_lakehouse_id`, which `DatabaseConfig`
+        is supposed to filter).
         """
         lakehouses = []
         for record in (self.cfg.get('database') or {}).get('lakehouses') or []:
             undeclared = sorted(set(record) - set(LakehouseConfig._fields))
-            if undeclared:
+            seen = (record.get('id', ''), tuple(undeclared))
+            if undeclared and seen not in _WARNED_UNDECLARED:
+                _WARNED_UNDECLARED.add(seen)
                 logger.warning(
                     'Lakehouse %r carries %s, which this plaidcloud-config does not declare '
                     'and is dropping. Upgrade the library before relying on them.',
-                    record.get('id', ''), ', '.join(undeclared),
+                    seen[0], ', '.join(undeclared),
                 )
             lakehouses.append(
                 LakehouseConfig(**{k: v for k, v in record.items() if k in LakehouseConfig._fields})

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -114,12 +114,34 @@ class LakehouseConfig(NamedTuple):
 #: namespace. Anything else is PlaidCloud-provisioned. Keyed on the credential ref rather than
 #: `engine` because that is what cp-rest's own `reconcile_default_lakehouse` keys on; an engine
 #: test would misfile the first customer StarRocks.
+#:
+#: The `lh-` plus 32 lowercase hex anchoring is cp-rest's and is load-bearing there: a looser
+#: `lakehouse_.*_password` also matches `lakehouse_admin_password` and every
+#: `lakehouse_user_<name>_password`. This is a SECOND copy of that pattern with no shared
+#: source — if cp-rest's `mint_lakehouse_id` shape ever changes, both must move together.
+#:
+#: It FAILS OPEN, deliberately: anything unrecognised (absent, empty, legacy, uppercase hex,
+#: hand-edited) reads as PlaidCloud-provisioned and inherits the tenant block. That is the
+#: right way round for the shapes cp-rest emits, where the only non-matching ref is the legacy
+#: provisioned one. On a hand-edited values file it means a malformed customer ref inherits
+#: the tenant's superuser and Lakekeeper token; cp-rest cannot produce that, and failing the
+#: other way would refuse every real provisioned record.
 _CUSTOMER_CREDENTIAL_REF = re.compile(r'^lakehouse_lh-[0-9a-f]{32}_password$')
 
-#: What a customer record inherits: nothing. The empty `superuser` is what makes a missing
-#: principal raise, and the class-default Iceberg coordinates are right because a warehouse
-#: PlaidCloud does not run has no tenant Lakekeeper.
-_NO_INHERITANCE = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
+#: Engines whose connection principal is a fixed constant, not a configured account. Databricks
+#: authenticates with a PAT as the password against the literal user `token` (plaid's own URLs
+#: are `databricks://token:<pat>@host`), so cp-rest deliberately omits `superuser` from its
+#: required set — the field is rendered into the Git-committed values file, and demanding it
+#: invites an operator to paste the PAT there.
+_FIXED_PRINCIPAL = {'databricks': 'token'}
+
+#: What a customer record inherits: nothing. The empty `superuser` is what makes a genuinely
+#: missing principal raise, and the Iceberg coordinates are EMPTY rather than
+#: `DatabaseConfig`'s class defaults — those name `http://lakekeeper:8181`, a Service that
+#: exists in no tenant namespace, so handing it to a customer warehouse would be a fabricated
+#: coordinate rather than an absent one.
+_NO_INHERITANCE = DatabaseConfig(hostname="", port=None, superuser="", password="", system="",
+                                 iceberg_catalog="", lakekeeper_url="", lakekeeper_warehouse="")
 
 
 def resolve_lakehouse(lakehouse: LakehouseConfig, tenant_default: DatabaseConfig,
@@ -149,19 +171,23 @@ def resolve_lakehouse(lakehouse: LakehouseConfig, tenant_default: DatabaseConfig
             f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) is disabled and cannot be connected to'
         )
     coordinates = lakehouse.coordinates or {}
-    hostname = coordinates.get('hostname') or ''
+    hostname = (coordinates.get('hostname') or '').strip()
     if not lakehouse.engine or not hostname:
         raise ValueError(
             f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) names no warehouse: '
             f'engine={lakehouse.engine!r}, coordinates.hostname={hostname!r}'
         )
 
-    inherited = _NO_INHERITANCE if is_customer_lakehouse(lakehouse) else tenant_default
-    superuser = lakehouse.superuser or inherited.superuser
+    customer = is_customer_lakehouse(lakehouse)
+    inherited = _NO_INHERITANCE if customer else tenant_default
+    superuser = (lakehouse.superuser or _FIXED_PRINCIPAL.get(lakehouse.engine)
+                 or inherited.superuser)
     if not superuser:
         raise ValueError(
-            f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) has no superuser and is not '
-            'PlaidCloud-provisioned, so there is no tenant default to fall back to'
+            f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) names no connection principal: '
+            f'the record has no superuser, engine {lakehouse.engine!r} has no fixed one, and '
+            + ('a customer record inherits none' if customer
+               else 'the tenant default has none either')
         )
     catalog = lakehouse.catalog or {}
     return DatabaseConfig(

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -128,18 +128,28 @@ class LakehouseConfig(NamedTuple):
 #: other way would refuse every real provisioned record.
 _CUSTOMER_CREDENTIAL_REF = re.compile(r'^lakehouse_lh-[0-9a-f]{32}_password$')
 
-#: Engines whose connection principal is a fixed constant, not a configured account. Databricks
-#: authenticates with a PAT as the password against the literal user `token` (plaid's own URLs
-#: are `databricks://token:<pat>@host`), so cp-rest deliberately omits `superuser` from its
-#: required set — the field is rendered into the Git-committed values file, and demanding it
-#: invites an operator to paste the PAT there.
+#: The principal to use when an engine's record carries none, for engines that conventionally
+#: take a constant rather than a configured account. cp-rest omits `superuser` from Databricks'
+#: required set on purpose — the field is rendered into the Git-committed values file, so
+#: demanding it invites an operator to paste the PAT there.
+#:
+#: `token` is the PAT convention, corroborated by cp-rest's comment and by plaid's own fixtures
+#: (`databricks://token:x@host:443/default`). It is NOT universal: Databricks OAuth M2M
+#: authenticates a service principal by client id, and plaid's own customer-connection builder
+#: (`connection.py` `_form_connection_string`) takes the username from `db_user` rather than
+#: hardcoding anything. So this is a DEFAULT, not a rule — a record that names a `superuser`
+#: always wins, which is the only escape hatch a non-PAT auth mode has.
 _FIXED_PRINCIPAL = {'databricks': 'token'}
 
 #: What a customer record inherits: nothing. The empty `superuser` is what makes a genuinely
 #: missing principal raise, and the Iceberg coordinates are EMPTY rather than
 #: `DatabaseConfig`'s class defaults — those name `http://lakekeeper:8181`, a Service that
-#: exists in no tenant namespace, so handing it to a customer warehouse would be a fabricated
-#: coordinate rather than an absent one.
+#: exists in no tenant namespace. Empty is also what plaid reads as "no Iceberg half": a
+#: truthy URL sends `drop_schema` and the `getattr(db, 'LAKEKEEPER_URL', None)` probes down
+#: the Iceberg branch, so a fabricated default would aim them at a Lakekeeper this warehouse
+#: has nothing to do with. All three are spelled out even though `lakekeeper_warehouse`'s
+#: class default is already '' — so that a change to `DatabaseConfig`'s defaults cannot
+#: silently re-fabricate one of them.
 _NO_INHERITANCE = DatabaseConfig(hostname="", port=None, superuser="", password="", system="",
                                  iceberg_catalog="", lakekeeper_url="", lakekeeper_warehouse="")
 

--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -9,6 +9,7 @@ __maintainer__ = "Garrett Bates"
 __email__ = "garrett@plaidcloud.com"
 
 """Loads the configuration file used by plaid apps in kubernetes."""
+import logging
 import os
 import yaml
 from typing import NamedTuple
@@ -18,6 +19,8 @@ from plaidcloud.config.rabbitmq import RMQConfig
 CONFIG_PATH = os.environ.get('PLAID_CONFIG_PATH', '/etc/plaidcloud/config.yaml')
 ENV_OVERRIDE_PREFIX = 'PLAID_CFG'
 ENV_OVERRIDE_SEP = '00'
+
+logger = logging.getLogger(__name__)
 
 
 def _apply_env_overrides(cfg: dict) -> None:
@@ -68,15 +71,94 @@ class LakehouseConfig(NamedTuple):
 
     `catalog` and `compute` are nullable by design: the control plane owns neither, and a
     default here would be a stale copy of somebody else's.
+
+    ⚠️ `coordinates`, `catalog` and `compute` stay NESTED, and are unpacked in exactly one
+    place — `resolve_lakehouse`. They are not free-form: they are cp-rest's
+    `LakehouseCoordinates` / `LakehouseCatalog` / `LakehouseCompute` models
+    (`router/tenant.py`), which is the shape the values file actually carries. Promoting
+    their members to top-level fields here would not flatten the record, it would stop
+    parsing it — a rendered `coordinates:` block would match no declared field and every
+    lakehouse would resolve to an empty hostname.
     """
     id: str = ""
     name: str = ""
     engine: str = ""
     status: str = ""
+    # `disabled`, not `enabled`, and False is the safe zero value: the provisioned record every
+    # tenant carries does not stamp it, so a missing key must read as "on". Dropping it silently
+    # (which the field filter did until it was declared) is how an operator-disabled lakehouse
+    # comes back connectable.
+    disabled: bool = False
+    # The connection principal. NOT a coordinate — two logins against one host, port and
+    # database are one physical store — so it is top-level, as cp-rest emits it.
+    superuser: str = ""
     coordinates: dict = {}
     catalog: dict | None = None
     compute: dict | None = None
     credential_ref: str = ""
+
+
+#: The `catalog` members that are `DatabaseConfig` fields. Omitted rather than passed empty
+#: when the record does not carry them: cp-rest sets `catalog: None` on the warehouses it
+#: provisions precisely because it does not own these coordinates, so the answer there is
+#: `DatabaseConfig`'s own defaults, not `''`.
+_CATALOG_FIELDS = ('iceberg_catalog', 'lakekeeper_url', 'lakekeeper_warehouse')
+
+
+def resolve_lakehouse(lakehouse: LakehouseConfig, password: str) -> DatabaseConfig:
+    """The connectable form of one lakehouse: a `DatabaseConfig`, ready for
+    `plaid.core.data.orm.build_lakehouse_dsns`.
+
+    A `DatabaseConfig` and not a widened `LakehouseConfig`, because two consumers read the
+    type and not just the attributes. `orm.build_lakehouse_dsns` reads `system`, `superuser`,
+    `hostname`, `port`, `database_name`, `query_params` and `password` under those names; and
+    `orm.lakehouse_fingerprint` — the engine-cache key — iterates `DatabaseConfig._fields`
+    with `getattr(..., None)`, so any other type drops whatever it happens not to declare out
+    of the key and lets two lakehouses share one engine. `database_tools`' Iceberg half reads
+    `iceberg_catalog` / `lakekeeper_*` off the same record, again under these names.
+
+    `password` is an ARGUMENT because it is not in the record and must not be: a lakehouse
+    names its credential with `credential_ref`, a Vault key name, and nothing in this library
+    resolves it. The caller supplies the credential it read.
+
+    `cloud_url` is left at its default on purpose — the legacy shared-Postgres catalog is one
+    per tenant, is read from `cfg.database` by `orm.build_shared_dsns`, and is not a lakehouse
+    coordinate. `lakekeeper_token` is left at its default for the duller reason that the
+    control plane's record has no field for it; a StarRocks lakehouse whose Lakekeeper needs a
+    token cannot get one through here yet.
+
+    Refuses a disabled lakehouse rather than returning something connectable: this is the only
+    seam in this library where that flag can bite, and a kill switch nothing reads is
+    decoration. `status` is deliberately NOT refused — `retired` blocks new project bindings
+    (cp-rest `LAKEHOUSE_STATUSES`), it does not stop the projects already there from reading.
+    """
+    if lakehouse.disabled:
+        raise ValueError(
+            f'lakehouse {lakehouse.id!r} ({lakehouse.name!r}) is disabled and cannot be connected to'
+        )
+    coordinates = lakehouse.coordinates or {}
+    catalog = lakehouse.catalog or {}
+    compute = lakehouse.compute or {}
+    return DatabaseConfig(
+        hostname=coordinates.get('hostname', ''),
+        # None for an engine whose URL takes no port (Snowflake); `URL.create` accepts it.
+        port=coordinates.get('port'),
+        superuser=lakehouse.superuser,
+        password=password,
+        # `engine` and `system` range over the same words — starrocks, databend, snowflake,
+        # databricks (`lakehouse_tools.LAKEHOUSE_ENGINES`, and the chart renders
+        # `system: {{ externalDatabase.protocol }}`).
+        system=lakehouse.engine,
+        # Passed through as the control plane recorded it, including ''. The in-cluster
+        # engines render an empty database name, and substituting `DatabaseConfig`'s
+        # 'plaid_data' default would be this library guessing a warehouse.
+        database_name=coordinates.get('database_name') or '',
+        # Compute selection rides the DSN query string: Snowflake picks it with
+        # warehouse/role, Databricks with http_path. Unset members serialize as null and
+        # would otherwise render as literal 'None' in the URL.
+        query_params={k: v for k, v in compute.items() if v is not None},
+        **{k: catalog[k] for k in _CATALOG_FIELDS if catalog.get(k)},
+    )
 
 
 class EnvironmentConfig(NamedTuple):
@@ -259,12 +341,33 @@ class PlaidConfig:
 
         Empty on every tenant whose values file predates the render — an absent collection is
         not an error, it is a tenant that has not been republished yet.
+
+        Undeclared keys are still dropped rather than raised on, because a values render
+        landing ahead of a library bump must not TypeError inside every plaid pod on the
+        tenant — that rollout order is what `LakehouseConfig` exists ahead of its consumers
+        for. But the drop is LOGGED. Silence is what let cp-rest's `disabled` and `superuser`
+        disappear here for a whole release: a record said a warehouse was switched off, this
+        filter discarded the key, and the result was a lakehouse that read as enabled with
+        nothing anywhere saying otherwise.
+
+        Only lakehouse records are checked. Every other block filters undeclared keys
+        deliberately and constantly — `database:` alone carries `lakehouses` and
+        `default_lakehouse_id`, which `DatabaseConfig` drops by design — so a library-wide
+        warning would be noise on every pod start, and noise is the same as silence.
         """
-        db_config = self.cfg.get('database') or {}
-        return [
-            LakehouseConfig(**{k: v for k, v in lakehouse.items() if k in LakehouseConfig._fields})
-            for lakehouse in db_config.get('lakehouses') or []
-        ]
+        lakehouses = []
+        for record in (self.cfg.get('database') or {}).get('lakehouses') or []:
+            undeclared = sorted(set(record) - set(LakehouseConfig._fields))
+            if undeclared:
+                logger.warning(
+                    'Lakehouse %r carries %s, which this plaidcloud-config does not declare '
+                    'and is dropping. Upgrade the library before relying on them.',
+                    record.get('id', ''), ', '.join(undeclared),
+                )
+            lakehouses.append(
+                LakehouseConfig(**{k: v for k, v in record.items() if k in LakehouseConfig._fields})
+            )
+        return lakehouses
 
     @property
     def default_lakehouse_id(self) -> str:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -245,6 +245,15 @@ def empty_config(tmp_path, monkeypatch):
 
 
 @pytest.fixture
+def fresh_warnings(monkeypatch):
+    """Give the test an empty 'already reported this undeclared key' set.
+
+    `PlaidConfig.lakehouses` warns once per (id, keys) for the life of the process, so without
+    this a test's warning depends on whether an earlier test already tripped it."""
+    monkeypatch.setattr(_get_config_module(), "_WARNED_UNDECLARED", set())
+
+
+@pytest.fixture
 def missing_config(monkeypatch):
     """Return a PlaidConfig when no config file exists."""
     config_mod = _get_config_module()

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -9,6 +9,7 @@ __maintainer__ = "Garrett Bates"
 __email__ = "garrett@plaidcloud.com"
 
 """Tests for plaidcloud.config.config module."""
+import logging
 import sys
 import yaml
 import pytest
@@ -598,6 +599,30 @@ LAKEHOUSE_CFG = {
 }
 
 
+# A record exactly as cp-rest's `build_customer_lakehouse` emits one: `disabled` and
+# `superuser` at top level beside the nested coordinate/catalog/compute blocks.
+CUSTOMER_LAKEHOUSE_CFG = {
+    "database": {
+        "default_lakehouse_id": "lh-3333",
+        "lakehouses": [
+            {
+                "id": "lh-3333",
+                "name": "Customer Snowflake",
+                "engine": "snowflake",
+                "status": "active",
+                "disabled": True,
+                "superuser": "SVC_PLAID",
+                "coordinates": {"hostname": "acme-x1.snowflakecomputing.com", "port": None,
+                                "database_name": "PLAID_DATA"},
+                "catalog": None,
+                "compute": {"warehouse": "PLAID_WH", "role": "PLAID_ROLE", "http_path": None},
+                "credential_ref": "lakehouse_lh-3333_password",
+            },
+        ],
+    }
+}
+
+
 def _config_from(tmp_path, monkeypatch, cfg):
     config_path = tmp_path / "cfg.yaml"
     config_path.write_text(yaml.dump(cfg))
@@ -653,6 +678,35 @@ class TestLakehouses:
         assert lakehouse.id == "lh-1"
         assert not hasattr(lakehouse, "role")
 
+    def test_extra_keys_are_dropped_out_loud(self, tmp_path, monkeypatch, caplog):
+        # Ignored is not the same as unnoticed. `disabled` and `superuser` went missing here
+        # for a release because the filter discarded them without a word.
+        cfg = {"database": {"lakehouses": [{"id": "lh-1", "role": "primary", "tier": "gold"}]}}
+        with caplog.at_level(logging.WARNING, logger="plaidcloud.config.config"):
+            assert _config_from(tmp_path, monkeypatch, cfg).lakehouses
+        assert "lh-1" in caplog.text
+        assert "role, tier" in caplog.text
+
+    def test_a_fully_declared_record_says_nothing(self, tmp_path, monkeypatch, caplog):
+        # The warning has to be a signal, not a per-pod-start constant.
+        with caplog.at_level(logging.WARNING, logger="plaidcloud.config.config"):
+            assert _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
+        assert caplog.text == ""
+
+    def test_parses_the_fields_cp_rest_emits_at_top_level(self, tmp_path, monkeypatch):
+        # `build_customer_lakehouse` emits `disabled` and `superuser` beside the nested blocks.
+        # Dropped, a disabled lakehouse reads as enabled and a DSN is built with no principal.
+        lakehouse, = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
+        assert lakehouse.disabled is True
+        assert lakehouse.superuser == "SVC_PLAID"
+
+    def test_disabled_defaults_to_false_when_absent(self, tmp_path, monkeypatch):
+        # The provisioned record every tenant already carries does not stamp `disabled`, so the
+        # zero value has to be the one that leaves that lakehouse usable.
+        starrocks = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses[1]
+        assert starrocks.disabled is False
+        assert starrocks.superuser == ""
+
     def test_credential_ref_is_a_key_name_not_a_credential(self, tmp_path, monkeypatch):
         # Nothing here resolves the ref, and no field carries a secret — the record is safe to
         # commit to the values file in Git, which is exactly where it comes from.
@@ -675,3 +729,96 @@ class TestDefaultLakehouseId:
         # tenant has one lakehouse, and silently wrong the moment it has two.
         cfg = {"database": {"lakehouses": [{"id": "lh-1"}, {"id": "lh-2"}]}}
         assert _config_from(tmp_path, monkeypatch, cfg).default_lakehouse_id == ""
+
+
+class TestResolveLakehouse:
+    """`resolve_lakehouse` — the connectable form of a lakehouse record.
+
+    The contract under test is `plaid.core.data.orm.build_lakehouse_dsns`, which reads
+    `system`, `superuser`, `hostname`, `port`, `database_name`, `query_params` and `password`
+    off whatever it is handed, and `orm.lakehouse_fingerprint`, which iterates
+    `DatabaseConfig._fields`.
+    """
+
+    def _lakehouse(self, tmp_path, monkeypatch, cfg, **overrides):
+        lakehouse, = _config_from(tmp_path, monkeypatch, cfg).lakehouses
+        return lakehouse._replace(**overrides)
+
+    def test_returns_a_database_config(self, tmp_path, monkeypatch):
+        # The TYPE and not just the attributes: `lakehouse_fingerprint` builds the engine-cache
+        # key from `DatabaseConfig._fields`, so a record of another type drops whatever it does
+        # not declare out of the key and two lakehouses quietly share one engine.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert isinstance(config_mod.resolve_lakehouse(lakehouse, "pw"), DatabaseConfig)
+
+    def test_every_field_build_lakehouse_dsns_reads(self, tmp_path, monkeypatch):
+        starrocks = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses[1]
+        resolved = config_mod.resolve_lakehouse(starrocks._replace(superuser="root"), "pw")
+        assert resolved.system == "starrocks"
+        assert resolved.superuser == "root"
+        assert resolved.hostname == "starrocks-fe-service"
+        assert resolved.port == 9030
+        assert resolved.database_name == ""
+        assert resolved.query_params == {}
+        assert resolved.password == "pw"
+
+    def test_the_password_comes_from_the_caller_not_the_record(self, tmp_path, monkeypatch):
+        # `credential_ref` is a Vault key NAME. Nothing here resolves it, so the credential
+        # cannot come from anywhere but the argument.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert config_mod.resolve_lakehouse(lakehouse, "from-vault").password == "from-vault"
+
+    def test_snowflake_coordinates_carry_no_port(self, tmp_path, monkeypatch):
+        # A Snowflake account URL takes no port; `URL.create` accepts None and omits it.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        assert resolved.port is None
+        assert resolved.hostname == "acme-x1.snowflakecomputing.com"
+        assert resolved.database_name == "PLAID_DATA"
+
+    def test_compute_becomes_query_params(self, tmp_path, monkeypatch):
+        # Snowflake selects compute with warehouse/role, Databricks with http_path; both ride
+        # the DSN query string. Unset members are null and must not render as literal 'None'.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        assert resolved.query_params == {"warehouse": "PLAID_WH", "role": "PLAID_ROLE"}
+
+    def test_a_null_catalog_leaves_the_iceberg_defaults_alone(self, tmp_path, monkeypatch):
+        # cp-rest sets `catalog: None` on the warehouses it provisions because it does not own
+        # these coordinates. Rendering that as '' would blank a working Lakekeeper.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        untouched = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
+        assert resolved.iceberg_catalog == untouched.iceberg_catalog
+        assert resolved.lakekeeper_url == untouched.lakekeeper_url
+        assert resolved.lakekeeper_warehouse == untouched.lakekeeper_warehouse
+
+    def test_a_populated_catalog_wins(self, tmp_path, monkeypatch):
+        lakehouse = self._lakehouse(
+            tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False,
+            catalog={"iceberg_catalog": "ice2", "lakekeeper_url": "http://lk-b:8181",
+                     "lakekeeper_warehouse": "wh2"},
+        )
+        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        assert resolved.iceberg_catalog == "ice2"
+        assert resolved.lakekeeper_url == "http://lk-b:8181"
+        assert resolved.lakekeeper_warehouse == "wh2"
+
+    def test_cloud_url_is_not_a_lakehouse_coordinate(self, tmp_path, monkeypatch):
+        # One shared-Postgres catalog per tenant, read from `cfg.database` by
+        # `orm.build_shared_dsns`. A per-lakehouse copy would aim it at the wrong tenant.
+        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert config_mod.resolve_lakehouse(lakehouse, "pw").cloud_url == ""
+
+    def test_a_disabled_lakehouse_is_refused(self, tmp_path, monkeypatch):
+        # This is the only seam in this library where the flag can bite. Returning something
+        # connectable here is what makes `disabled` decoration.
+        lakehouse, = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
+        with pytest.raises(ValueError, match="lh-3333"):
+            config_mod.resolve_lakehouse(lakehouse, "pw")
+
+    def test_a_retired_lakehouse_is_not_refused(self, tmp_path, monkeypatch):
+        # `retired` blocks NEW project bindings; the projects already there still read.
+        databend = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses[0]
+        assert databend.status == "retired"
+        assert config_mod.resolve_lakehouse(databend, "pw").hostname == "plaid-databend-query"

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -599,14 +599,65 @@ LAKEHOUSE_CFG = {
 }
 
 
-# A record exactly as cp-rest's `build_customer_lakehouse` emits one: `disabled` and
-# `superuser` at top level beside the nested coordinate/catalog/compute blocks.
-CUSTOMER_LAKEHOUSE_CFG = {
+# THE RECORD EVERY TENANT ON THE FLEET CARRIES. Copied key-for-key from cp-rest's
+# `lakehouse_tools.mint_tenant_lakehouse`, which emits exactly these eight keys: NO
+# `superuser`, NO `disabled`, and `catalog: None` because cp-rest does not own the
+# Iceberg/Lakekeeper coordinates. Tests that patch a superuser onto a record are testing a
+# precondition production does not have.
+MINTED_LAKEHOUSE_CFG = {
     "database": {
-        "default_lakehouse_id": "lh-3333",
+        # The tenant's own block, which is what a provisioned record re-describes. The
+        # lakekeeper_url is the per-release Service the chart actually renders
+        # (configmap-tenant.yaml), NOT DatabaseConfig's class default.
+        "hostname": "starrocks-fe-service",
+        "port": 9030,
+        "superuser": "root",
+        "password": "tenant-pw",
+        "system": "starrocks",
+        "iceberg_catalog": "tenant_catalog",
+        "lakekeeper_url": "http://plaid-tenant-lakekeeper:8181",
+        "lakekeeper_warehouse": "tenant_wh",
+        "lakekeeper_token": "tenant-token",
+        "cloud_url": "postgresql://c1:pw@plaid-shared-postgres:5432/cloud_1",
+        "default_lakehouse_id": "lh-mint",
         "lakehouses": [
             {
-                "id": "lh-3333",
+                "id": "lh-mint",
+                "name": "StarRocks",
+                "engine": "starrocks",
+                "status": "provisioning",
+                "coordinates": {"hostname": "starrocks-fe-service", "port": 9030,
+                                "database_name": ""},
+                "catalog": None,
+                "compute": None,
+                "credential_ref": "lakehouse_admin_password",
+            },
+        ],
+    }
+}
+
+
+# A record exactly as cp-rest's `build_customer_lakehouse` emits one: `disabled` and
+# `superuser` at top level beside the nested coordinate/catalog/compute blocks.
+# `id` and `credential_ref` are a real `mint_lakehouse_id` shape — `lh-` plus 32 hex. That is
+# load-bearing, not decoration: cp-rest's `is_credential_ref` anchors on exactly that pattern,
+# and it is how a customer record is told apart from a provisioned one.
+CUSTOMER_ID = "lh-0123456789abcdef0123456789abcdef"
+CUSTOMER_LAKEHOUSE_CFG = {
+    "database": {
+        # Present so a test can prove these are NOT inherited by a customer record.
+        "hostname": "starrocks-fe-service",
+        "port": 9030,
+        "superuser": "root",
+        "password": "tenant-pw",
+        "system": "starrocks",
+        "lakekeeper_url": "http://plaid-tenant-lakekeeper:8181",
+        "lakekeeper_token": "tenant-token",
+        "cloud_url": "postgresql://c1:pw@plaid-shared-postgres:5432/cloud_1",
+        "default_lakehouse_id": CUSTOMER_ID,
+        "lakehouses": [
+            {
+                "id": CUSTOMER_ID,
                 "name": "Customer Snowflake",
                 "engine": "snowflake",
                 "status": "active",
@@ -616,7 +667,7 @@ CUSTOMER_LAKEHOUSE_CFG = {
                                 "database_name": "PLAID_DATA"},
                 "catalog": None,
                 "compute": {"warehouse": "PLAID_WH", "role": "PLAID_ROLE", "http_path": None},
-                "credential_ref": "lakehouse_lh-3333_password",
+                "credential_ref": f"lakehouse_{CUSTOMER_ID}_password",
             },
         ],
     }
@@ -678,6 +729,7 @@ class TestLakehouses:
         assert lakehouse.id == "lh-1"
         assert not hasattr(lakehouse, "role")
 
+    @pytest.mark.usefixtures("fresh_warnings")
     def test_extra_keys_are_dropped_out_loud(self, tmp_path, monkeypatch, caplog):
         # Ignored is not the same as unnoticed. `disabled` and `superuser` went missing here
         # for a release because the filter discarded them without a word.
@@ -687,6 +739,19 @@ class TestLakehouses:
         assert "lh-1" in caplog.text
         assert "role, tier" in caplog.text
 
+    @pytest.mark.usefixtures("fresh_warnings")
+    def test_the_warning_does_not_repeat_per_read(self, tmp_path, monkeypatch, caplog):
+        # `lakehouses` is a PROPERTY and plaid re-reads it on every project resolution. A
+        # warning that repeats per read floods exactly the rollout window it exists to report,
+        # and a flood is as unreadable as silence.
+        cfg = {"database": {"lakehouses": [{"id": "lh-1", "role": "primary"}]}}
+        parsed = _config_from(tmp_path, monkeypatch, cfg)
+        with caplog.at_level(logging.WARNING, logger="plaidcloud.config.config"):
+            for _ in range(5):
+                assert parsed.lakehouses
+        assert caplog.text.count("lh-1") == 1
+
+    @pytest.mark.usefixtures("fresh_warnings")
     def test_a_fully_declared_record_says_nothing(self, tmp_path, monkeypatch, caplog):
         # The warning has to be a signal, not a per-pod-start constant.
         with caplog.at_level(logging.WARNING, logger="plaidcloud.config.config"):
@@ -740,20 +805,93 @@ class TestResolveLakehouse:
     `DatabaseConfig._fields`.
     """
 
-    def _lakehouse(self, tmp_path, monkeypatch, cfg, **overrides):
-        lakehouse, = _config_from(tmp_path, monkeypatch, cfg).lakehouses
-        return lakehouse._replace(**overrides)
+    def _resolve(self, tmp_path, monkeypatch, cfg, password="pw", **overrides):
+        """Resolve the one lakehouse in `cfg` against that same config's `database:` block —
+        the pairing production has, rather than a hand-built default."""
+        parsed = _config_from(tmp_path, monkeypatch, cfg)
+        lakehouse, = parsed.lakehouses
+        return config_mod.resolve_lakehouse(
+            lakehouse._replace(**overrides), parsed.database, password)
+
+    # --- the record the fleet actually carries -----------------------------------------
+
+    def test_a_minted_record_inherits_the_tenant_superuser(self, tmp_path, monkeypatch):
+        # `mint_tenant_lakehouse` emits NO `superuser`. Resolving without a fallback yields a
+        # blank principal and a DSN nothing can authenticate.
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert resolved.superuser == "root"
+
+    def test_a_minted_record_inherits_the_tenant_lakekeeper(self, tmp_path, monkeypatch):
+        # `catalog: None` must NOT mean DatabaseConfig's class defaults: the class default
+        # `http://lakekeeper:8181` names no Service in a tenant namespace, and
+        # `_lakehouse_coordinate` reads a stamped lakehouse with no fallback to cfg.database.
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert resolved.lakekeeper_url == "http://plaid-tenant-lakekeeper:8181"
+        assert resolved.iceberg_catalog == "tenant_catalog"
+        assert resolved.lakekeeper_warehouse == "tenant_wh"
+
+    def test_a_minted_record_inherits_the_tenant_lakekeeper_token(self, tmp_path, monkeypatch):
+        # `LakehouseCatalog` has no token field at all, so inheritance is the only source.
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert resolved.lakekeeper_token == "tenant-token"
+
+    def test_a_minted_record_resolves_while_provisioning(self, tmp_path, monkeypatch):
+        # `create_tenant` mints `status='provisioning'` and only flips it when the tenant
+        # reaches running, so bootstrap MUST be able to connect to build the warehouse.
+        parsed = _config_from(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert parsed.lakehouses[0].status == "provisioning"
+        assert self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG).hostname
+
+    def test_a_minted_record_is_not_a_customer_lakehouse(self, tmp_path, monkeypatch):
+        lakehouse, = _config_from(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG).lakehouses
+        assert config_mod.is_customer_lakehouse(lakehouse) is False
+
+    # --- a customer record inherits nothing --------------------------------------------
+
+    def test_a_customer_record_is_recognised(self, tmp_path, monkeypatch):
+        lakehouse, = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
+        assert config_mod.is_customer_lakehouse(lakehouse) is True
+
+    def test_a_customer_record_does_not_inherit_the_tenant_lakekeeper(self, tmp_path, monkeypatch):
+        # Falling back to the tenant's own StarRocks coordinates for a warehouse PlaidCloud
+        # does not run is the "answers for the wrong warehouse" failure.
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        untouched = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
+        assert resolved.lakekeeper_url == untouched.lakekeeper_url
+        assert resolved.iceberg_catalog == untouched.iceberg_catalog
+        assert resolved.lakekeeper_token == ""
+
+    def test_a_customer_record_with_no_superuser_is_refused(self, tmp_path, monkeypatch):
+        # Loud, not defaulted: there is no tenant principal that means anything on a
+        # warehouse the customer owns.
+        with pytest.raises(ValueError, match="no superuser"):
+            self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG,
+                          disabled=False, superuser="")
+
+    def test_a_customer_record_keeps_its_own_superuser(self, tmp_path, monkeypatch):
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert resolved.superuser == "SVC_PLAID"
+
+    def test_a_recorded_superuser_beats_the_tenant_default(self, tmp_path, monkeypatch):
+        # Precedence is only observable on a PROVISIONED record, where the tenant default is
+        # populated too. Inheritance fills a gap; it does not override what the record says.
+        parsed = _config_from(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert parsed.database.superuser == "root"
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+                                 superuser="recorded_admin")
+        assert resolved.superuser == "recorded_admin"
+
+    # --- the DSN contract ---------------------------------------------------------------
 
     def test_returns_a_database_config(self, tmp_path, monkeypatch):
         # The TYPE and not just the attributes: `lakehouse_fingerprint` builds the engine-cache
         # key from `DatabaseConfig._fields`, so a record of another type drops whatever it does
         # not declare out of the key and two lakehouses quietly share one engine.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        assert isinstance(config_mod.resolve_lakehouse(lakehouse, "pw"), DatabaseConfig)
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert isinstance(resolved, DatabaseConfig)
 
     def test_every_field_build_lakehouse_dsns_reads(self, tmp_path, monkeypatch):
-        starrocks = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses[1]
-        resolved = config_mod.resolve_lakehouse(starrocks._replace(superuser="root"), "pw")
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
         assert resolved.system == "starrocks"
         assert resolved.superuser == "root"
         assert resolved.hostname == "starrocks-fe-service"
@@ -762,63 +900,105 @@ class TestResolveLakehouse:
         assert resolved.query_params == {}
         assert resolved.password == "pw"
 
+    def test_carries_the_control_plane_id(self, tmp_path, monkeypatch):
+        # plaid's `assigned_lakehouse_id` reads `lakehouse_id` off the record. Without it,
+        # every member of a >1-lakehouse collection answers '' and every project binding fails
+        # to resolve.
+        assert self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG).lakehouse_id == "lh-mint"
+
     def test_the_password_comes_from_the_caller_not_the_record(self, tmp_path, monkeypatch):
         # `credential_ref` is a Vault key NAME. Nothing here resolves it, so the credential
-        # cannot come from anywhere but the argument.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        assert config_mod.resolve_lakehouse(lakehouse, "from-vault").password == "from-vault"
+        # cannot come from anywhere but the argument — not the record, not the tenant default.
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+                                 password="from-vault")
+        assert resolved.password == "from-vault"
 
     def test_snowflake_coordinates_carry_no_port(self, tmp_path, monkeypatch):
         # A Snowflake account URL takes no port; `URL.create` accepts None and omits it.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
         assert resolved.port is None
         assert resolved.hostname == "acme-x1.snowflakecomputing.com"
         assert resolved.database_name == "PLAID_DATA"
 
+    def test_a_null_database_name_does_not_become_the_string_none(self, tmp_path, monkeypatch):
+        resolved = self._resolve(
+            tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+            coordinates={"hostname": "h", "port": 1, "database_name": None})
+        assert resolved.database_name == ""
+
     def test_compute_becomes_query_params(self, tmp_path, monkeypatch):
         # Snowflake selects compute with warehouse/role, Databricks with http_path; both ride
-        # the DSN query string. Unset members are null and must not render as literal 'None'.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+        # the DSN query string.
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
         assert resolved.query_params == {"warehouse": "PLAID_WH", "role": "PLAID_ROLE"}
 
-    def test_a_null_catalog_leaves_the_iceberg_defaults_alone(self, tmp_path, monkeypatch):
-        # cp-rest sets `catalog: None` on the warehouses it provisions because it does not own
-        # these coordinates. Rendering that as '' would blank a working Lakekeeper.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
-        untouched = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
-        assert resolved.iceberg_catalog == untouched.iceberg_catalog
-        assert resolved.lakekeeper_url == untouched.lakekeeper_url
-        assert resolved.lakekeeper_warehouse == untouched.lakekeeper_warehouse
+    def test_empty_compute_members_are_absent_not_blank(self, tmp_path, monkeypatch):
+        # cp-rest's `missing_connection_fields` treats '' as absent. Forwarding it renders
+        # `?role=`, which asks the vendor to assume a role named ''.
+        resolved = self._resolve(
+            tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False,
+            compute={"warehouse": "PLAID_WH", "role": "", "http_path": None})
+        assert resolved.query_params == {"warehouse": "PLAID_WH"}
+
+    def test_an_explicitly_empty_catalog_member_survives(self, tmp_path, monkeypatch):
+        # An operator setting this to '' is saying "no Iceberg here". A truthiness filter
+        # would discard that and substitute the tenant's catalog.
+        resolved = self._resolve(
+            tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+            catalog={"iceberg_catalog": "", "lakekeeper_url": "", "lakekeeper_warehouse": ""})
+        assert resolved.iceberg_catalog == ""
+        assert resolved.lakekeeper_url == ""
 
     def test_a_populated_catalog_wins(self, tmp_path, monkeypatch):
-        lakehouse = self._lakehouse(
-            tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False,
+        resolved = self._resolve(
+            tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
             catalog={"iceberg_catalog": "ice2", "lakekeeper_url": "http://lk-b:8181",
-                     "lakekeeper_warehouse": "wh2"},
-        )
-        resolved = config_mod.resolve_lakehouse(lakehouse, "pw")
+                     "lakekeeper_warehouse": "wh2"})
         assert resolved.iceberg_catalog == "ice2"
         assert resolved.lakekeeper_url == "http://lk-b:8181"
         assert resolved.lakekeeper_warehouse == "wh2"
 
-    def test_cloud_url_is_not_a_lakehouse_coordinate(self, tmp_path, monkeypatch):
+    def test_a_partial_catalog_inherits_only_what_it_omits(self, tmp_path, monkeypatch):
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+                                 catalog={"iceberg_catalog": "ice2"})
+        assert resolved.iceberg_catalog == "ice2"
+        assert resolved.lakekeeper_url == "http://plaid-tenant-lakekeeper:8181"
+
+    def test_cloud_url_is_never_per_lakehouse(self, tmp_path, monkeypatch):
         # One shared-Postgres catalog per tenant, read from `cfg.database` by
-        # `orm.build_shared_dsns`. A per-lakehouse copy would aim it at the wrong tenant.
-        lakehouse = self._lakehouse(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        assert config_mod.resolve_lakehouse(lakehouse, "pw").cloud_url == ""
+        # `orm.build_shared_dsns`. Neither the record nor the tenant default may seed it here:
+        # both carry one in this fixture, and the resolved record must still be blank.
+        parsed = _config_from(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        assert parsed.database.cloud_url
+        resolved = self._resolve(
+            tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+            coordinates={"hostname": "h", "port": 1, "database_name": "",
+                         "cloud_url": "postgresql://sneaky/x"})
+        assert resolved.cloud_url == ""
+
+    # --- refusals -----------------------------------------------------------------------
 
     def test_a_disabled_lakehouse_is_refused(self, tmp_path, monkeypatch):
         # This is the only seam in this library where the flag can bite. Returning something
         # connectable here is what makes `disabled` decoration.
-        lakehouse, = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
-        with pytest.raises(ValueError, match="lh-3333"):
-            config_mod.resolve_lakehouse(lakehouse, "pw")
+        with pytest.raises(ValueError, match=CUSTOMER_ID):
+            self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG)
 
     def test_a_retired_lakehouse_is_not_refused(self, tmp_path, monkeypatch):
-        # `retired` blocks NEW project bindings; the projects already there still read.
-        databend = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouses[0]
-        assert databend.status == "retired"
-        assert config_mod.resolve_lakehouse(databend, "pw").hostname == "plaid-databend-query"
+        # `retired` stops NEW project bindings; the projects already there still read.
+        resolved = self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, status="retired")
+        assert resolved.hostname == "starrocks-fe-service"
+
+    def test_a_record_naming_no_host_is_refused(self, tmp_path, monkeypatch):
+        # Otherwise this renders `starrocks://root:pw@/`, which fails as a connection error a
+        # long way from the config that caused it.
+        with pytest.raises(ValueError, match="names no warehouse"):
+            self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, coordinates={})
+
+    def test_a_record_naming_no_engine_is_refused(self, tmp_path, monkeypatch):
+        with pytest.raises(ValueError, match="names no warehouse"):
+            self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, engine="")
+
+    def test_a_null_coordinates_block_is_refused(self, tmp_path, monkeypatch):
+        with pytest.raises(ValueError, match="names no warehouse"):
+            self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, coordinates=None)

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -958,6 +958,22 @@ class TestResolveLakehouse:
         resolved = self._resolve(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG)
         assert resolved.query_params == {"http_path": "/sql/1.0/warehouses/abc123"}
 
+    def test_a_recorded_superuser_beats_the_engine_constant(self, tmp_path, monkeypatch):
+        # THE precedence that makes `_FIXED_PRINCIPAL` a default rather than a rule. `token` is
+        # the PAT convention, but Databricks OAuth M2M authenticates a service principal by
+        # CLIENT ID, and the record's own `superuser` is the only escape hatch such a record
+        # has. A "simplification" putting the constant first — "Databricks is always token" —
+        # would silently reroute every one of them.
+        resolved = self._resolve(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG,
+                                 superuser="7a1b2c3d-client-id")
+        assert resolved.superuser == "7a1b2c3d-client-id"
+
+    def test_the_fixed_principal_table_is_databricks_only(self):
+        # Membership is the whole behaviour of the table: an entry for an engine that DOES take
+        # a configured account would mask a missing superuser instead of raising, and would
+        # override the tenant default on every provisioned record of that engine.
+        assert getattr(config_mod, "_FIXED_PRINCIPAL") == {"databricks": "token"}
+
     def test_the_engine_principal_beats_an_inherited_one(self, tmp_path, monkeypatch):
         # Precedence between the engine constant and inheritance is only observable when BOTH
         # are populated, which needs a Databricks record carrying the legacy (provisioned)
@@ -1114,9 +1130,31 @@ class TestResolveLakehouse:
         with pytest.raises(ValueError, match="names no warehouse"):
             self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, coordinates=None)
 
-    def test_a_blank_hostname_is_refused(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("blank", ["   ", "\t", "\n", " \t "])
+    def test_a_blank_hostname_is_refused(self, tmp_path, monkeypatch, blank):
         # Whitespace is not a host. Unstripped it passes the emptiness check and renders
-        # `starrocks://root:pw@%20%20%20:9030/`.
+        # `starrocks://root:pw@%20%20%20:9030/`. Tabs too — `.strip(' ')` would let one past.
         with pytest.raises(ValueError, match="names no warehouse"):
             self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
-                          coordinates={"hostname": "   ", "port": 9030, "database_name": ""})
+                          coordinates={"hostname": blank, "port": 9030, "database_name": ""})
+
+    def test_the_stored_hostname_is_stripped(self, tmp_path, monkeypatch):
+        # Guarding only the refusal leaves the padding in the DSN, where it percent-encodes
+        # into the host and resolves nowhere.
+        resolved = self._resolve(
+            tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+            coordinates={"hostname": " \tstarrocks-fe-service \n", "port": 9030,
+                         "database_name": ""})
+        assert resolved.hostname == "starrocks-fe-service"
+
+    def test_the_refusal_names_which_side_had_no_principal(self, tmp_path, monkeypatch):
+        # The two branches say opposite things about where to look; swapping them sends an
+        # operator to the wrong file.
+        with pytest.raises(ValueError, match="a customer record inherits none"):
+            self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG,
+                          disabled=False, superuser="")
+        parsed = _config_from(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG)
+        lakehouse, = parsed.lakehouses
+        with pytest.raises(ValueError, match="the tenant default has none either"):
+            config_mod.resolve_lakehouse(
+                lakehouse, parsed.database._replace(superuser=""), "pw")

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -10,6 +10,7 @@ __email__ = "garrett@plaidcloud.com"
 
 """Tests for plaidcloud.config.config module."""
 import logging
+import re
 import sys
 import yaml
 import pytest
@@ -674,6 +675,41 @@ CUSTOMER_LAKEHOUSE_CFG = {
 }
 
 
+# The OTHER customer engine, and the one the superuser rule turns on. cp-rest's
+# `_REQUIRED_CONNECTION_FIELDS['databricks']` is ('hostname', 'http_path') — NO superuser —
+# because the only correct principal is the literal `token` and `superuser` is rendered into
+# the Git-committed values file, so demanding it invites an operator to paste the PAT there.
+DATABRICKS_ID = "lh-fedcba9876543210fedcba9876543210"
+DATABRICKS_LAKEHOUSE_CFG = {
+    "database": {
+        "hostname": "starrocks-fe-service",
+        "port": 9030,
+        "superuser": "root",
+        "password": "tenant-pw",
+        "system": "starrocks",
+        "lakekeeper_url": "http://plaid-tenant-lakekeeper:8181",
+        "lakekeeper_token": "tenant-token",
+        "default_lakehouse_id": DATABRICKS_ID,
+        "lakehouses": [
+            {
+                "id": DATABRICKS_ID,
+                "name": "Customer Databricks",
+                "engine": "databricks",
+                "status": "active",
+                "disabled": False,
+                "superuser": "",
+                "coordinates": {"hostname": "acme.cloud.databricks.com", "port": 443,
+                                "database_name": ""},
+                "catalog": None,
+                "compute": {"warehouse": None, "role": None,
+                            "http_path": "/sql/1.0/warehouses/abc123"},
+                "credential_ref": f"lakehouse_{DATABRICKS_ID}_password",
+            },
+        ],
+    }
+}
+
+
 def _config_from(tmp_path, monkeypatch, cfg):
     config_path = tmp_path / "cfg.yaml"
     config_path.write_text(yaml.dump(cfg))
@@ -852,19 +888,94 @@ class TestResolveLakehouse:
         lakehouse, = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG).lakehouses
         assert config_mod.is_customer_lakehouse(lakehouse) is True
 
+    @pytest.mark.parametrize("ref", [
+        "lakehouse_admin_password",                     # the legacy provisioned key
+        "lakehouse_user_alice_password",                # a per-user key, id would be 'user_alice'
+        "lakehouse_lh-notrealhex_password",             # right prefix, wrong body
+        "lakehouse_lh-0123456789ABCDEF0123456789ABCDEF_password",   # uppercase hex
+        "lakehouse_lh-0123456789abcdef0123456789abcde_password",    # 31 hex, not 32
+        f"lakehouse_{CUSTOMER_ID}_password ",           # trailing whitespace
+        f"lakehouse_{CUSTOMER_ID}_password\n",          # trailing newline: `$` matches before it
+        f"x lakehouse_{CUSTOMER_ID}_password",          # embedded, not the whole key
+        "",
+    ])
+    def test_only_a_minted_credential_ref_is_a_customer_lakehouse(self, ref):
+        # cp-rest calls this anchoring load-bearing: a loose `lakehouse_.*_password` also
+        # matches the legacy shared key and every per-user key, which would flip the tenant's
+        # own warehouse to "customer" and strip its inheritance.
+        assert config_mod.is_customer_lakehouse(
+            config_mod.LakehouseConfig(id="x", credential_ref=ref)) is False
+
+    def test_the_credential_ref_pattern_is_cp_rests_verbatim(self):
+        # This is a SECOND copy of `lakehouse_tools._CREDENTIAL_REF_RE` with no shared source,
+        # and cp-rest documents the exact anchoring as load-bearing. Pinned as a string so any
+        # edit here is deliberate and gets checked against the other copy — including edits
+        # that are behaviourally equivalent under `fullmatch` and would otherwise slip through.
+        pattern = getattr(config_mod, "_CUSTOMER_CREDENTIAL_REF")
+        assert pattern.pattern == r'^lakehouse_lh-[0-9a-f]{32}_password$'
+        assert pattern.flags & re.IGNORECASE == 0
+
     def test_a_customer_record_does_not_inherit_the_tenant_lakekeeper(self, tmp_path, monkeypatch):
         # Falling back to the tenant's own StarRocks coordinates for a warehouse PlaidCloud
         # does not run is the "answers for the wrong warehouse" failure.
         resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
-        untouched = DatabaseConfig(hostname="", port=None, superuser="", password="", system="")
-        assert resolved.lakekeeper_url == untouched.lakekeeper_url
-        assert resolved.iceberg_catalog == untouched.iceberg_catalog
+        assert resolved.lakekeeper_url != "http://plaid-tenant-lakekeeper:8181"
         assert resolved.lakekeeper_token == ""
 
-    def test_a_customer_record_with_no_superuser_is_refused(self, tmp_path, monkeypatch):
-        # Loud, not defaulted: there is no tenant principal that means anything on a
-        # warehouse the customer owns.
-        with pytest.raises(ValueError, match="no superuser"):
+    def test_a_customer_catalog_is_absent_not_a_fabricated_default(self, tmp_path, monkeypatch):
+        # `catalog: None` is cp-rest's default and its only way to say "no catalog".
+        # DatabaseConfig's class defaults are NOT that: `http://lakekeeper:8181` names a
+        # Service that exists in no tenant namespace, so serving it here invents a coordinate.
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert resolved.lakekeeper_url == ""
+        assert resolved.iceberg_catalog == ""
+        assert resolved.lakekeeper_warehouse == ""
+
+    def test_a_customer_snowflake_keeps_its_own_drivername(self, tmp_path, monkeypatch):
+        # `system` selects the SQLAlchemy driver. The tenant default is 'starrocks' here, so
+        # sourcing it from there instead of the record would build `starrocks://` against a
+        # Snowflake account with nothing to show for it.
+        parsed = _config_from(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG)
+        assert parsed.database.system == "starrocks"
+        resolved = self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG, disabled=False)
+        assert resolved.system == "snowflake"
+
+    # --- Databricks: an engine that takes no configured principal ------------------------
+
+    def test_a_databricks_record_needs_no_recorded_superuser(self, tmp_path, monkeypatch):
+        # cp-rest's `_REQUIRED_CONNECTION_FIELDS['databricks']` is ('hostname', 'http_path').
+        # Refusing a blank superuser here would refuse a shape the control plane accepts and
+        # this story exists to support.
+        resolved = self._resolve(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG)
+        assert resolved.superuser == "token"
+
+    def test_a_databricks_record_keeps_its_own_drivername(self, tmp_path, monkeypatch):
+        resolved = self._resolve(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG)
+        assert resolved.system == "databricks"
+        assert resolved.hostname == "acme.cloud.databricks.com"
+
+    def test_a_databricks_http_path_rides_query_params(self, tmp_path, monkeypatch):
+        resolved = self._resolve(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG)
+        assert resolved.query_params == {"http_path": "/sql/1.0/warehouses/abc123"}
+
+    def test_the_engine_principal_beats_an_inherited_one(self, tmp_path, monkeypatch):
+        # Precedence between the engine constant and inheritance is only observable when BOTH
+        # are populated, which needs a Databricks record carrying the legacy (provisioned)
+        # credential ref — reachable only by hand-editing a values file, but that is exactly
+        # where a wrong answer would go unnoticed. There is no `root` account on a Databricks
+        # warehouse, so the constant has to win.
+        parsed = _config_from(tmp_path, monkeypatch, DATABRICKS_LAKEHOUSE_CFG)
+        assert parsed.database.superuser == "root"
+        lakehouse, = parsed.lakehouses
+        hand_edited = lakehouse._replace(credential_ref="lakehouse_admin_password")
+        assert config_mod.is_customer_lakehouse(hand_edited) is False
+        resolved = config_mod.resolve_lakehouse(hand_edited, parsed.database, "pw")
+        assert resolved.superuser == "token"
+
+    def test_a_customer_snowflake_with_no_superuser_is_refused(self, tmp_path, monkeypatch):
+        # Snowflake DOES require a principal (`_REQUIRED_CONNECTION_FIELDS`), and there is no
+        # tenant principal that means anything on a warehouse the customer owns.
+        with pytest.raises(ValueError, match="no connection principal"):
             self._resolve(tmp_path, monkeypatch, CUSTOMER_LAKEHOUSE_CFG,
                           disabled=False, superuser="")
 
@@ -1002,3 +1113,10 @@ class TestResolveLakehouse:
     def test_a_null_coordinates_block_is_refused(self, tmp_path, monkeypatch):
         with pytest.raises(ValueError, match="names no warehouse"):
             self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG, coordinates=None)
+
+    def test_a_blank_hostname_is_refused(self, tmp_path, monkeypatch):
+        # Whitespace is not a host. Unstripped it passes the emptiness check and renders
+        # `starrocks://root:pw@%20%20%20:9030/`.
+        with pytest.raises(ValueError, match="names no warehouse"):
+            self._resolve(tmp_path, monkeypatch, MINTED_LAKEHOUSE_CFG,
+                          coordinates={"hostname": "   ", "port": 9030, "database_name": ""})


### PR DESCRIPTION
# Make a `LakehouseConfig` connectable (sc-23158 step 1)

`LakehouseConfig` mirrored the control plane's Lakehouse record but could not be turned into a
database connection, so a tenant's second lakehouse had no route to a DSN. This adds that route.

Everything upstream has shipped: cp-rest records lakehouses and writes their credentials to
Vault, the tenant chart renders the collection, and plaid can be told which lakehouse to act on.
This is the missing conversion in the middle.

## What it adds

**`resolve_lakehouse(lakehouse, tenant_default, password) -> DatabaseConfig`** — the connectable
form of one lakehouse, ready for `plaid.core.data.orm.build_lakehouse_dsns` with no change to
that function.

It returns a `DatabaseConfig` because the **type** is read, not just the attributes:
`orm.lakehouse_fingerprint` builds the engine-cache key by iterating `DatabaseConfig._fields`, so
any other type silently drops fields out of the key and lets two lakehouses share one engine.

**Two fields on `LakehouseConfig`: `disabled` and `superuser`.** cp-rest's
`build_customer_lakehouse` emits both at top level, and the field filter was discarding them
without a word — which is how an operator-disabled lakehouse read back as enabled, and how a DSN
got built with no principal.

**`lakehouse_id` on `DatabaseConfig`**, appended and defaulted. plaid's `assigned_lakehouse_id`
reads it off the record; without one, every member of a multi-lakehouse collection answers `''`,
`lakehouse_by_id` never matches, and every project binding fails to resolve.

**The undeclared-key drop is now logged**, once per record-and-key-set rather than on every
property read — `lakehouses` is a property that plaid re-reads on every project resolution, and a
per-read warning would flood the exact rollout window it exists to report. Keys are still dropped
rather than raised on, so a values render can land ahead of a library bump without a `TypeError`
in every pod.

## The inheritance rule

`coordinates`, `catalog` and `compute` stay nested — that is cp-rest's wire shape
(`LakehouseCoordinates` / `LakehouseCatalog` / `LakehouseCompute`) — and `resolve_lakehouse` is
the only thing that unpacks them.

**A PlaidCloud-provisioned record inherits from `tenant_default` (`cfg.database`).** It
re-describes the warehouse `cfg.database` already addresses. This is load-bearing:
`mint_tenant_lakehouse` emits **no `superuser`** and **`catalog: None`**, so without inheritance
the record every tenant carries resolves to a blank principal and to `DatabaseConfig`'s
class-default `lakekeeper_url` — which names no Service in a tenant namespace, where the chart
renders `http://<release>-lakekeeper:8181`. `_lakehouse_coordinate.__get__` falls back to
`cfg.database` only when *no* lakehouse is stamped, so a stamped-but-wrong value wins outright.

**A customer record inherits nothing.** It is the whole truth about a warehouse PlaidCloud does
not run, and falling back to the tenant's own warehouse there is the "resolver that answers for
the wrong warehouse while looking like it worked" failure.

**The discriminator** is cp-rest's own: a credential ref in the per-lakehouse vault-only
namespace (`^lakehouse_lh-[0-9a-f]{32}_password$`) means customer-owned. Keyed on the credential
ref rather than `engine` because that is what `reconcile_default_lakehouse` keys on — an engine
test would misfile the first customer StarRocks. Two caveats, both stated in the source:

- This is a **second copy** of `lakehouse_tools._CREDENTIAL_REF_RE` with no shared source. The
  anchoring is load-bearing (a loose `lakehouse_.*_password` also matches the legacy shared key
  and every per-user key), so the pattern is pinned as a string in a test and the two copies must
  move together.
- It **fails open**: anything unrecognised reads as provisioned and inherits. That is the right
  way round for the shapes cp-rest emits, where the only non-matching ref is the legacy
  provisioned one. On a hand-edited values file a malformed customer ref would inherit the
  tenant's superuser and Lakekeeper token; cp-rest cannot produce that, and failing the other way
  would refuse every real provisioned record.

## The Databricks principal — and its caveat

A customer Databricks record legitimately carries `superuser: ''`. cp-rest's
`_REQUIRED_CONNECTION_FIELDS['databricks']` is `('hostname', 'http_path')` with no superuser, on
the reasoning that the field is rendered into the **Git-committed** values file and demanding it
invites an operator to paste the PAT there. Refusing that shape would refuse the exact record
this story exists to support.

So `_FIXED_PRINCIPAL = {'databricks': 'token'}` supplies the PAT convention, producing
`databricks://token:<pat>@host`.

**Caveat, deliberately not overstated.** `token` is corroborated by cp-rest's comment and by
plaid's own fixtures (`databricks://token:x@host:443/default`), but **not** by plaid's real
customer-connection builder — `connection.py`'s `_form_connection_string` takes the username from
`db_user` and hardcodes nothing. And it is not universal: Databricks OAuth M2M authenticates a
service principal by **client id**, not `token`.

It is therefore a **default, not a rule**: a record that names a `superuser` always wins. That
precedence is the escape hatch every non-PAT auth mode has, and it is pinned by a test —
reordering the two silently reroutes every such record, and did pass an entire earlier suite.

Bounded today regardless: `build_lakehouse_dsns` has no Databricks arm yet.

## What `_NO_INHERITANCE` leaves empty, and why

For a customer record, `iceberg_catalog`, `lakekeeper_url` and `lakekeeper_warehouse` resolve to
`''` rather than `DatabaseConfig`'s class defaults.

Two reasons, and the second is the important one:

1. `http://lakekeeper:8181` names a Service that exists in no tenant namespace.
2. **`''` is how plaid reads "no Iceberg half".** It makes `drop_schema` take the plain-SQL path,
   makes `copy_macro_port`'s `is_iceberg` false, and makes the
   `getattr(db, 'LAKEKEEPER_URL', None)` probes fall to the non-Iceberg branch. The class default
   is **truthy** — it would take the Iceberg branch and, on a tenant that does run Lakekeeper,
   aim at the wrong one.

All three are spelled out explicitly even though `lakekeeper_warehouse`'s class default is
already `''`, so a future change to `DatabaseConfig`'s defaults cannot silently re-fabricate one.

`lakekeeper_token` follows the same rule: `LakehouseCatalog` has no token field, so a customer
record gets `''` and a provisioned one inherits the tenant's — the token for the Lakekeeper it is
actually pointed at.

`cloud_url` is never per-lakehouse. The legacy shared-Postgres catalog is one per tenant and
`orm.build_shared_dsns` reads it from `cfg.database`.

## Refusals

- **Disabled** — the only seam in this library where that flag can bite; a kill switch nothing
  reads is decoration.
- **Names no warehouse** — blank `engine` or `hostname` (whitespace included, and the stored
  hostname is trimmed) rather than rendering `starrocks://:pw@/`, which fails as a connection
  error a long way from the config that caused it.
- **No connection principal** — for an engine that takes one, with a message naming which side
  came up empty.

**`status` is deliberately not refused.** `create_tenant` mints `provisioning` and tenant
bootstrap must connect to that record in order to build the warehouse — `bootstrap.py` iterates
`provisioning_lakehouses()`, which has no status filter, and `activate_lakehouses` only flips the
status once the tenant reaches `running`. Refusing it would deadlock tenant creation. `retired`
still has to serve the projects already on it.

`password` stays out of the record entirely and is an argument: a lakehouse names its credential
with `credential_ref`, a Vault key name, and nothing in this library resolves it. The existing
test asserting `"password" not in LakehouseConfig._fields` is untouched.

## Backwards compatibility

Verified by diffing every `PlaidConfig` property, master vs branch, on a lakehouse-free config:
**20 properties, exactly one value difference** — `DatabaseConfig` gains `lakehouse_id=''`. Every
pre-existing field's value is byte-identical.

Widening `DatabaseConfig` is safe: every construction site across plaid, cp-rest and this repo is
keyword-only, and `lakehouse_identity`'s `_IDENTITY_FORMAT` is an explicit seven-component string
rather than `_fields`, so **on-disk manifests do not rebase**. `lakehouse_fingerprint` does change,
but its only use is the in-process `Connection.engines` key, and the change is correct: two
lakehouses with identical coordinates and different control-plane ids stop sharing an engine.

plaid pins `plaidcloud-config==0.1.66`, whose tag contains no `LakehouseConfig` at all.

## Tests

162 passed (baseline on `origin/master` was 106). `pylint -E` clean; the pylint warning set is
identical to master's, so nothing new was introduced.

Every new test is null-controlled: **48/48 mutants killed** under a strict rule — a mutant counts
as killed only when pytest returns exit code 1 **and** reports `N failed` **and** reports no
`error`, and every node is run unmutated first and must pass. That rule matters: an earlier
harness keyed on `returncode != 0` counted collection errors and typo'd node ids as kills. Every
precedence and table-membership mutant runs against the **whole file**, because a claim about an
*absent* guard shows up in no single node — which is exactly how the recorded-superuser
precedence slipped past a 43/43 sweep.

## Nothing consumes this yet

The tenant chart renders `lakehouses:` only under `{{- with (.Values.externalDatabase).lakehouses }}`
(`configmap-tenant.yaml:142-143`, `external-secret-tenant-config.yaml:304-305`), and **no tenant
values file sets the key** — so `cfg.lakehouses` is `[]` on all 30 tenants today (counted at
`plaid-tenant-applications@6d360c075`; that number moves as tenants come and go).

So this is inert on merge. It becomes live when cp-rest publishes a collection into a tenant's
values file, and plaid can only use it once `plaidcloud-config` is cut and plaid's pin moves off
`0.1.66`.

**One cross-repo follow-up for the plaid side:** `database_tools.py:492` says `DatabaseConfig`
"has no such field and is not getting one" about `lakehouse_id`. This PR adds it. The same prose
appears at `:1058` and in `test_project_lakehouse_binding.py:27`. Nothing goes red —
`assigned_lakehouse_id` already reads it through `getattr` — but the comments become false and
should be corrected when the pin moves.
