### PR TITLE
feat(config): expose the tenant's lakehouse credentials map (sc-23158)

### DIFF
--- a/python/plaidcloud/config/config.py
+++ b/python/plaidcloud/config/config.py
@@ -454,6 +454,27 @@ class PlaidConfig:
         return (self.cfg.get('database') or {}).get('default_lakehouse_id') or ""
 
     @property
+    def lakehouse_credentials(self) -> dict[str, str]:
+        """The secrets `credential_ref` names, keyed by that ref — `resolve_lakehouse`'s
+        `password` argument comes from here.
+
+        The chart renders this beside `lakehouses:` (one entry per DISTINCT ref) because the
+        record itself must stay committable to Git. Without this accessor there is no way to
+        read it: `DatabaseConfig`'s field filter drops it, deliberately, and `LakehouseConfig`
+        declares no password field.
+
+        Empty on every tenant whose values file predates the render — the chart emits the map
+        only inside `with .lakehouses`, so no collection means no map, and that is a tenant not
+        yet republished rather than an error.
+
+        ⚠️ VALUES ARE SECRETS. Nothing here may be logged, repr'd or put in an exception
+        message; the keys are safe (they are Vault key names), the values never are. Note that
+        a value may be the chart's `MISSING-VAULT-KEY-<ref>` sentinel, which is a real password
+        the tenant's Vault entry does not carry.
+        """
+        return (self.cfg.get('database') or {}).get('lakehouse_credentials') or {}
+
+    @property
     def environment(self) -> EnvironmentConfig:
         env_config = self.cfg.get('environment', {})
         ec = EnvironmentConfig(**{k: v for k, v in env_config.items() if k in EnvironmentConfig._fields})

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -574,6 +574,9 @@ LAKEHOUSE_CFG = {
         "password": "pw",
         "system": "starrocks",
         "default_lakehouse_id": "lh-2222",
+        # Rendered beside `lakehouses:`, one entry per DISTINCT `credential_ref` — both
+        # records below name the same ref, and the chart's `uniq` collapses them to one.
+        "lakehouse_credentials": {"lakehouse_admin_password": "lh-secret"},
         "lakehouses": [
             {
                 "id": "lh-1111",
@@ -730,10 +733,12 @@ class TestLakehouseCollectionIsInertUntilDeclared:
         assert db.system == "starrocks"
 
     def test_the_collection_is_not_a_database_field(self, tmp_path, monkeypatch):
-        # Read through `lakehouses` / `default_lakehouse_id`, never `cfg.database`.
+        # Read through `lakehouses` / `default_lakehouse_id` / `lakehouse_credentials`, never
+        # `cfg.database`.
         db = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).database
         assert "lakehouses" not in db._fields
         assert "default_lakehouse_id" not in db._fields
+        assert "lakehouse_credentials" not in db._fields
 
 
 class TestLakehouses:
@@ -830,6 +835,58 @@ class TestDefaultLakehouseId:
         # tenant has one lakehouse, and silently wrong the moment it has two.
         cfg = {"database": {"lakehouses": [{"id": "lh-1"}, {"id": "lh-2"}]}}
         assert _config_from(tmp_path, monkeypatch, cfg).default_lakehouse_id == ""
+
+
+class TestLakehouseCredentials:
+    """The other half of `credential_ref`: the chart joins the ref to its Vault value and
+    renders the map beside `lakehouses:`. Without this accessor `resolve_lakehouse`'s
+    `password` argument has no source in this library at all."""
+
+    def test_reads_the_map(self, tmp_path, monkeypatch):
+        credentials = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG).lakehouse_credentials
+        assert credentials == {"lakehouse_admin_password": "lh-secret"}
+
+    def test_absent_map_is_empty_not_an_error(self, tmp_path, monkeypatch, missing_config,
+                                              plaid_config):
+        # The rollout property everything else rests on: this library is read by services that
+        # pin an older one, and a tenant whose values file predates the render carries no map.
+        # `plaid_config` has a full `database:` block and no `lakehouse_credentials` in it;
+        # `missing_config` has no config file at all; the third is `database:` written with
+        # nothing under it, which YAML loads as None — the case the neighbouring
+        # `lakehouses` / `default_lakehouse_id` guards also exist for.
+        assert plaid_config.lakehouse_credentials == {}
+        assert missing_config.lakehouse_credentials == {}
+        assert _config_from(tmp_path, monkeypatch, {"database": None}).lakehouse_credentials == {}
+
+    def test_a_ref_resolves_to_its_credential(self, tmp_path, monkeypatch):
+        # The join the whole field exists for, spelled out: a record names a key, the map
+        # carries that key's value, and that value is what `resolve_lakehouse` is handed.
+        parsed = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG)
+        resolved = config_mod.resolve_lakehouse(
+            parsed.lakehouses[1],
+            parsed.database,
+            parsed.lakehouse_credentials[parsed.lakehouses[1].credential_ref],
+        )
+        assert resolved.password == "lh-secret"
+
+    def test_a_customer_ref_is_a_key_like_any_other(self, tmp_path, monkeypatch):
+        # `lakehouse_lh-<32hex>_password` is the shape cp-rest mints for a customer-owned
+        # warehouse, and it is a dict key here — no parsing, no per-engine handling.
+        ref = f"lakehouse_{CUSTOMER_ID}_password"
+        cfg = {"database": {"lakehouses": [{"id": CUSTOMER_ID, "credential_ref": ref}],
+                            "lakehouse_credentials": {ref: "customer-secret"}}}
+        assert _config_from(tmp_path, monkeypatch, cfg).lakehouse_credentials[ref] == "customer-secret"
+
+    def test_no_credential_value_reaches_a_log_or_a_repr(self, tmp_path, monkeypatch, caplog):
+        # These are the only secrets this library hands out that are not inside a NamedTuple
+        # field somebody already treats as one. Parsing must stay silent, and `str(cfg)` — the
+        # one dump path PlaidConfig has — must not grow into a config dump.
+        parsed = _config_from(tmp_path, monkeypatch, LAKEHOUSE_CFG)
+        with caplog.at_level(logging.DEBUG, logger="plaidcloud.config.config"):
+            assert parsed.lakehouse_credentials
+        assert "lh-secret" not in caplog.text
+        assert "lh-secret" not in str(parsed)
+        assert "lh-secret" not in repr(parsed)
 
 
 class TestResolveLakehouse:


### PR DESCRIPTION
## What

Adds `PlaidConfig.lakehouse_credentials` — the map the tenant chart now renders into the tenant secret, keyed by Vault key name.

```yaml
database:
  lakehouse_credentials:
    "lakehouse_lh-<32hex>_password": "…"
    "lakehouse_admin_password": "…"
```

## Why

`resolve_lakehouse(lakehouse, tenant_default, password)` (merged at `ce7b484`) takes the credential as an **argument**, because a lakehouse record deliberately carries only `credential_ref` — the *name* of a Vault key, never the value.

`plaid-tenant-infrastructure` #934 renders those values into the tenant secret. This library had no accessor for them, so `DatabaseConfig`'s field filter dropped the map and nothing could supply that argument. **`resolve_lakehouse` has zero callers anywhere** — this is why.

One property, one-line body, matching `default_lakehouse_id`'s shape: the same `(… or {})` guard on the `database:` block and the same `or {}` absence default. An absent key is a tenant not yet republished, not an error.

## Backwards compatibility

The highest-risk property here — other services read this library, and plaid pins an older version.

Proven, not asserted: a harness imported master's package and the branch's package in **separate processes** and dumped `self.cfg`, `str()`, all 20 pre-existing properties (with `vars()` for the two that define no `__repr__`) and three `feature()` calls, across 6 configs with the key stripped — sample, empty, `database: None`, and the three lakehouse fixtures.

```
master sha256  c9014380fe2a453f40d754e3524d7e08102757acfce8b486853a1f2069f0095d
branch sha256  c9014380fe2a453f40d754e3524d7e08102757acfce8b486853a1f2069f0095d
cmp EXIT=0
```

Property-surface delta: `+['lakehouse_credentials']`, removed `[]`.

## Secrets

This property returns secrets, so exposure was checked rather than assumed.

Static: the package has exactly one `logger.*` call, one `__str__`, no `__repr__`, no dump/`json.dumps`/`yaml.dump`.

Dynamic canary — a unique sentinel as the only credential value, root logger at DEBUG, every property plus `str`/`repr`/`feature` plus `resolve_lakehouse` on three records including a disabled one and one whose undeclared extra key *held* the sentinel:

- **`SENTINEL in ANY log output: False`** — the undeclared-key warning logs key *names* only.
- `str(cfg)` / `repr(cfg)` clean; exception texts carry id/name/engine/hostname, never a value.
- The sentinel appears in exactly two places, both by design: `cfg.lakehouse_credentials` itself, and `DatabaseConfig.password` on a result the caller passed it to.

## Evidence

| | |
|---|---|
| baseline `ce7b484` | 162 passed, EXIT=0 |
| branch | 167 passed, EXIT=0 |
| `pylint -E python` | EXIT=0 both |
| mutation | 7 mutants, each rc==1 with a named FAILED test |

One mutant initially **survived** — `self.cfg.get('database', {})`, dropping the `None`-guard. The test was strengthened with a `{"database": None}` case; it now kills.

## Found, not fixed

- `repr(DatabaseConfig)` prints `password` in clear (a NamedTuple's default repr). Pre-existing and already true of `cfg.database.password`, but `resolve_lakehouse`'s return value inherits it — **any caller that logs a resolved lakehouse leaks the credential.** Worth closing when the wiring lands.
- A `credential_ref` with no map entry raises a bare `KeyError`. The failure mode belongs with the wiring, not here.
- `cfg.rabbitmq` raises `TypeError` on a config with no `rabbitmq:` block — pre-existing, the only property that does not degrade to defaults.